### PR TITLE
legacy os to grid

### DIFF
--- a/content/schedulers/_index.md
+++ b/content/schedulers/_index.md
@@ -146,6 +146,12 @@ wrapperCSSClass: "scheduler-types-section"
                                     <td class="icon-cell"><span class="icon u-greenCheckCircle"></span></td>
                                 </tr>
                                 <tr>
+                                    <td>Legacy OS support</td>
+                                    <td class="icon-cell"><span class="icon u-greenCheckCircle"></span></td>
+                                    <td class="icon-cell"><span class="icon u-grayFailCircle"></span></td>
+                                    <td class="icon-cell"><span class="icon u-grayFailCircle"></span></td>
+                                </tr>
+                                <tr>
                                     <td>Airgap support</td>
                                     <td class="icon-cell"><span class="icon u-greenCheckCircle"></span></td>
                                     <td class="icon-cell"><span class="icon u-grayFailCircle"></span></td>


### PR DESCRIPTION
updated grid to call out support for older docker versions Supports Docker 1.7.1 and later