### PR TITLE
Stop the premkit before deleting files

### DIFF
--- a/content/docs/kb/supporting-your-customers/creating-an-ami.md
+++ b/content/docs/kb/supporting-your-customers/creating-an-ami.md
@@ -41,7 +41,8 @@ instance of this server, it will be calculated again.
 sudo service replicated stop
 sudo service replicated-ui stop
 sudo service replicated-operator stop
-sudo docker rm -f replicated replicated-ui replicated-operator
+sudo docker stop replicated-premkit
+sudo docker rm -f replicated replicated-ui replicated-operator replicated-premkit
 ```
 
 ### Step 3: Remove config files


### PR DESCRIPTION
* `replicated-premkit` has the directories for the certificates mounted
* I have two theories where this causes a problem:
  * When the docker service is stopped, `replicated-premkit` is hanging
  onto files and ends up writing some directories to disk when the
  docker daemon is shut down
  * Or, when the docker daemon is started up as a fresh new AMI, the
  `replicated-premkit` container is started and it attempts to read the
  contents of the directories that are not existing and something ends
  up creating them
* Regardless, when the replicated service starts up as a fresh new AMI, it's not
very happy about these certificate directories existing.