### PR TITLE
[2.17] Add docs for swarm default metrics [ch5369]

### DIFF
--- a/content/docs/packaging-an-application/yaml-overview.md
+++ b/content/docs/packaging-an-application/yaml-overview.md
@@ -116,6 +116,16 @@ monitors:
   - Worker,quay.io/myenterpriseapp/worker
 ```
 
+When using the swarm scheduler, services can be monitored for resource usage metrics. For each metric, specify the service name.
+
+```yaml
+monitors:
+  cpuacct:
+  - redis-service
+  memory:
+  - redis-service
+```
+
 {{< linked_headline "Custom Metrics" >}}
 
 Regardless of the scheduler used, Replicated can also display [custom metrics](/docs/packaging-an-application/custom-metrics/) sent from the running instance to the Admin Console by including the stats names in a custom_metrics key.


### PR DESCRIPTION
Reverts replicatedhq/help-center#279 which reverted replicatedhq/help-center#277 which added documentation for swarm default metrics