### PR TITLE
Update support bundle docs with include_empty info

### DIFF
--- a/content/api/support-bundle-yaml-specs/docker-container-cp.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-cp.md
@@ -23,7 +23,7 @@ specs:
       output_dir: /www/access/
 ```
 
-    
+
 ### Required Parameters
 
 
@@ -33,16 +33,16 @@ specs:
 - `src_path` - The path of the target file in the container's filesystem
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.Name}}` - Output will match the name of the file. If `src_path` is `/var/log/nginx/access.log`, then `output_dir` will contain a file `access.log`
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-container-cp.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-cp.md
@@ -34,7 +34,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.Name}}` - Output will match the name of the file. If `src_path` is `/var/log/nginx/access.log`, then `output_dir` will contain a file `access.log`

--- a/content/api/support-bundle-yaml-specs/docker-container-exec.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-exec.md
@@ -36,7 +36,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `stdout.raw` - The standard output of the command

--- a/content/api/support-bundle-yaml-specs/docker-container-exec.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-exec.md
@@ -25,7 +25,7 @@ specs:
           - '-t'
 ```
 
-    
+
 ### Required Parameters
 
 
@@ -35,18 +35,18 @@ specs:
 - `exec_config` - Same as would be passed to `docker exec`, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/configs.go#L43)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `stdout.raw` - The standard output of the command
 
 - `stderr.raw` - The standard error of the command
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-container-inspect.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-inspect.md
@@ -38,7 +38,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.Name}}.json` - The json output of the inspect call. Will generate this file for each matched container

--- a/content/api/support-bundle-yaml-specs/docker-container-inspect.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-inspect.md
@@ -27,7 +27,7 @@ specs:
             - dnsmasq
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -37,16 +37,16 @@ specs:
 - `container_list_options` - Options to be used to filter the list of containers, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/client.go#L61)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.Name}}.json` - The json output of the inspect call. Will generate this file for each matched container
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-container-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-logs.md
@@ -40,7 +40,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.Name}}.stdout` - The stdout logs. Will generate this file for each matched container

--- a/content/api/support-bundle-yaml-specs/docker-container-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-logs.md
@@ -26,7 +26,7 @@ specs:
             - haproxy
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -39,18 +39,18 @@ specs:
 - `container_logs_options` - Args as would be given to `docker logs`, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/client.go#L73)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.Name}}.stdout` - The stdout logs. Will generate this file for each matched container
 
 - `{{.Name}}.stderr` - The stderr logs. Will generate this file for each matched container
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-container-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-ls.md
@@ -54,7 +54,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `container_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-container-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-ls.md
@@ -25,7 +25,7 @@ specs:
           - haproxy
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -53,16 +53,16 @@ specs:
 - `Size` - Option to be used to filter the list of containers, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/client.go#L61)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `container_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-container-run.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-run.md
@@ -31,32 +31,32 @@ specs:
           NetworkMode: host
 ```
 
-    
+
 ### Required Parameters
 
 
 - `container_create_config` - Container create options as would be passed to `docker run`
 
 
-    
+
 ### Optional Parameters
 
 
 - `enable_pull` - If `true`, allow this container to be pulled if not present
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `stdout.raw` - The standard output of the container
 
 - `stderr.raw` - The standard error of the container
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-container-run.md
+++ b/content/api/support-bundle-yaml-specs/docker-container-run.md
@@ -46,7 +46,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `stdout.raw` - The standard output of the container

--- a/content/api/support-bundle-yaml-specs/docker-exec.md
+++ b/content/api/support-bundle-yaml-specs/docker-exec.md
@@ -37,7 +37,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `stdout.raw` - The standard output of the command

--- a/content/api/support-bundle-yaml-specs/docker-exec.md
+++ b/content/api/support-bundle-yaml-specs/docker-exec.md
@@ -26,7 +26,7 @@ specs:
           - '--verbose'
 ```
 
-    
+
 ### Required Parameters
 
 
@@ -36,18 +36,18 @@ specs:
 - `exec_config` - Config options as would be passed to `docker exec`, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/configs.go)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `stdout.raw` - The standard output of the command
 
 - `stderr.raw` - The standard error of the command
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-image-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-image-ls.md
@@ -35,7 +35,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `image_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-image-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-image-ls.md
@@ -24,7 +24,7 @@ specs:
           - com.supercooltool.app=supercooltool-enterprise
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -34,16 +34,16 @@ specs:
 - `Filters` - Same as would be passed to `docker images`
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `image_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-images.md
+++ b/content/api/support-bundle-yaml-specs/docker-images.md
@@ -35,7 +35,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `image_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-images.md
+++ b/content/api/support-bundle-yaml-specs/docker-images.md
@@ -24,7 +24,7 @@ specs:
           - com.supercooltool.app=supercooltool-enterprise
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -34,16 +34,16 @@ specs:
 - `Filters` - Same as would be passed to `docker images`
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `image_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-info.md
+++ b/content/api/support-bundle-yaml-specs/docker-info.md
@@ -22,16 +22,16 @@ specs:
       description: Info about the docker daemon
 ```
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `docker_info.json` - A pretty-printed JSON representation
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-info.md
+++ b/content/api/support-bundle-yaml-specs/docker-info.md
@@ -23,7 +23,7 @@ specs:
 ```
 
 
-    ### Outputs
+### Outputs
 
     
 - `docker_info.json` - A pretty-printed JSON representation

--- a/content/api/support-bundle-yaml-specs/docker-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-logs.md
@@ -31,7 +31,7 @@ specs:
         Timestamps: true
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -44,18 +44,18 @@ specs:
 - `container_logs_options` - Args as would be given to `docker logs`, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/client.go#L73)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.Name}}.stdout` - The stdout logs. Will generate this file for each matched container
 
 - `{{.Name}}.stderr` - The stderr logs. Will generate this file for each matched container
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-logs.md
@@ -45,7 +45,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.Name}}.stdout` - The stdout logs. Will generate this file for each matched container

--- a/content/api/support-bundle-yaml-specs/docker-node-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-node-ls.md
@@ -32,7 +32,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `node_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-node-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-node-ls.md
@@ -24,23 +24,23 @@ specs:
           - cooltool-docker-swarm-
 ```
 
-    
+
 ### Optional Parameters
 
 
 - `Filters` - Same as would be passed to `docker node ls`
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `node_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-ps.md
+++ b/content/api/support-bundle-yaml-specs/docker-ps.md
@@ -50,7 +50,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `container_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-ps.md
+++ b/content/api/support-bundle-yaml-specs/docker-ps.md
@@ -21,7 +21,7 @@ specs:
       All: true
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -49,16 +49,16 @@ specs:
 - `Size` - Option to be used to filter the list of containers, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/client.go#L61)
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `container_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-run.md
+++ b/content/api/support-bundle-yaml-specs/docker-run.md
@@ -46,7 +46,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `stdout.raw` - The standard output of the container

--- a/content/api/support-bundle-yaml-specs/docker-run.md
+++ b/content/api/support-bundle-yaml-specs/docker-run.md
@@ -31,32 +31,32 @@ specs:
           NetworkMode: host
 ```
 
-    
+
 ### Required Parameters
 
 
 - `container_create_config` - Same as would be passed to `docker run`, as in [The Docker API](https://github.com/moby/moby/blob/master/api/types/configs.go#L13)
 
 
-    
+
 ### Optional Parameters
 
 
 - `enable_pull` - If `true`, allow this container to be pulled if not present
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `stdout.raw` - The standard output of the container
 
 - `stderr.raw` - The standard error of the container
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-service-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-service-logs.md
@@ -47,7 +47,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.Name}}.stdout` - The stdout output of the logs call. Will generate this file for each matched service

--- a/content/api/support-bundle-yaml-specs/docker-service-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-service-logs.md
@@ -33,7 +33,7 @@ specs:
             - cooltool-worker
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -46,18 +46,18 @@ specs:
 - `service_list_options` - Options for filtering all swarm services
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.Name}}.stdout` - The stdout output of the logs call. Will generate this file for each matched service
 
 - `{{.Name}}.stderr` - The stderr output of the logs call. Will generate this file for each matched service
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-service-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-service-ls.md
@@ -24,23 +24,23 @@ specs:
           - cooltool-
 ```
 
-    
+
 ### Optional Parameters
 
 
 - `Filters` - Same as would be passed to `docker service ls`
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `service_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-service-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-service-ls.md
@@ -32,7 +32,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `service_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-service-ps.md
+++ b/content/api/support-bundle-yaml-specs/docker-service-ps.md
@@ -24,23 +24,23 @@ specs:
           - cooltool-
 ```
 
-    
+
 ### Required Parameters
 
 
 - `Filters` - Same as would be passed to `docker service ps`
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `service_ps.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-service-ps.md
+++ b/content/api/support-bundle-yaml-specs/docker-service-ps.md
@@ -32,7 +32,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `service_ps.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-stack-service-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-service-logs.md
@@ -40,7 +40,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.StackName}}_{{.ServiceName}}.stdout` - The stdout output. Will generate this file for each matched service

--- a/content/api/support-bundle-yaml-specs/docker-stack-service-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-service-logs.md
@@ -22,14 +22,14 @@ specs:
       namespace: cooltool-core
 ```
 
-    
+
 ### Required Parameters
 
 
 - `namespace` - The stack's namespace
 
 
-    
+
 ### Optional Parameters
 
 
@@ -39,18 +39,18 @@ specs:
 - `service_list_options` - Options as would be passed to `docker stack services
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.StackName}}_{{.ServiceName}}.stdout` - The stdout output. Will generate this file for each matched service
 
 - `{{.StackName}}_{{.ServiceName}}.stderr` - The stderr output. Will generate this file for each matched service
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-stack-service-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-service-ls.md
@@ -37,7 +37,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `service_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-stack-service-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-service-ls.md
@@ -22,30 +22,30 @@ specs:
       namespace: cooltool-core
 ```
 
-    
+
 ### Required Parameters
 
 
 - `namespace` - The stack's namespace
 
 
-    
+
 ### Optional Parameters
 
 
 - `service_list_options` - Options as would be passed to `docker stack services
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `service_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-stack-service-ps.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-service-ps.md
@@ -27,30 +27,30 @@ specs:
             - com.cooltool.tier=api
 ```
 
-    
+
 ### Required Parameters
 
 
 - `namespace` - The stack's namespace
 
 
-    
+
 ### Optional Parameters
 
 
 - `task_list_options` - Options as would be passed to `docker stack ps`
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `service_ps.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-stack-service-ps.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-service-ps.md
@@ -42,7 +42,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `service_ps.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-stack-task-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-task-logs.md
@@ -45,7 +45,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.TaskId}}.stdout` - The stdout output. Will generate this file for each matched service task

--- a/content/api/support-bundle-yaml-specs/docker-stack-task-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-stack-task-logs.md
@@ -27,14 +27,14 @@ specs:
             - com.cooltool.tier=api
 ```
 
-    
+
 ### Required Parameters
 
 
 - `namespace` - The stack namespace
 
 
-    
+
 ### Optional Parameters
 
 
@@ -44,18 +44,18 @@ specs:
 - `task_list_options` - Options for filtering stack tasks
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.TaskId}}.stdout` - The stdout output. Will generate this file for each matched service task
 
 - `{{.TaskId}}.stderr` - The stderr output. Will generate this file for each matched service task
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-task-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-task-logs.md
@@ -40,7 +40,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `{{.TaskId}}.stdout` - The stdout output. Will generate this file for each matched service task

--- a/content/api/support-bundle-yaml-specs/docker-task-logs.md
+++ b/content/api/support-bundle-yaml-specs/docker-task-logs.md
@@ -26,7 +26,7 @@ specs:
             - com.cooltool.tier=api
 ```
 
-    
+
 ### Optional Parameters
 
 
@@ -39,18 +39,18 @@ specs:
 - `task_list_options` - Options for filtering stack tasks
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `{{.TaskId}}.stdout` - The stdout output. Will generate this file for each matched service task
 
 - `{{.TaskId}}.stderr` - The stderr output. Will generate this file for each matched service task
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-task-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-task-ls.md
@@ -24,23 +24,23 @@ specs:
           - cooltool-backend-
 ```
 
-    
+
 ### Optional Parameters
 
 
 - `Filters` - Filters for tasks
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `task_ls.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-task-ls.md
+++ b/content/api/support-bundle-yaml-specs/docker-task-ls.md
@@ -32,7 +32,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `task_ls.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/docker-version.md
+++ b/content/api/support-bundle-yaml-specs/docker-version.md
@@ -20,16 +20,16 @@ specs:
       output_dir: /docker/version
 ```
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `docker_version.json` - JSON output
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/docker-version.md
+++ b/content/api/support-bundle-yaml-specs/docker-version.md
@@ -21,7 +21,7 @@ specs:
 ```
 
 
-    ### Outputs
+### Outputs
 
     
 - `docker_version.json` - JSON output

--- a/content/api/support-bundle-yaml-specs/journald-logs.md
+++ b/content/api/support-bundle-yaml-specs/journald-logs.md
@@ -41,7 +41,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `logs.raw` - The raw output the `journald` logs for the unit

--- a/content/api/support-bundle-yaml-specs/journald-logs.md
+++ b/content/api/support-bundle-yaml-specs/journald-logs.md
@@ -23,14 +23,14 @@ specs:
       since: '2018-01-01'
 ```
 
-    
+
 ### Required Parameters
 
 
 - `unit` - Systemd unit from which to collect logs
 
 
-    
+
 ### Optional Parameters
 
 
@@ -40,16 +40,16 @@ specs:
 - `since` - Since date for log collection
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `logs.raw` - The raw output the `journald` logs for the unit
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/os-hostname.md
+++ b/content/api/support-bundle-yaml-specs/os-hostname.md
@@ -20,18 +20,18 @@ specs:
       output_dir: /system/hostname
 ```
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `stderr` - The stdout from the command
 
 - `stdout` - The stdin from the command
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/os-hostname.md
+++ b/content/api/support-bundle-yaml-specs/os-hostname.md
@@ -21,7 +21,7 @@ specs:
 ```
 
 
-    ### Outputs
+### Outputs
 
     
 - `stderr` - The stdout from the command

--- a/content/api/support-bundle-yaml-specs/os-http-request.md
+++ b/content/api/support-bundle-yaml-specs/os-http-request.md
@@ -49,7 +49,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `body` - The response body

--- a/content/api/support-bundle-yaml-specs/os-http-request.md
+++ b/content/api/support-bundle-yaml-specs/os-http-request.md
@@ -25,7 +25,7 @@ specs:
           - cooltool/supportbundle 0.11.1
 ```
 
-    
+
 ### Required Parameters
 
 
@@ -35,7 +35,7 @@ specs:
 - `url` - The HTTP request URL
 
 
-    
+
 ### Optional Parameters
 
 
@@ -48,16 +48,16 @@ specs:
 - `insecure` - Set to `true` to skip TLS verification
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `body` - The response body
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/os-loadavg.md
+++ b/content/api/support-bundle-yaml-specs/os-loadavg.md
@@ -28,7 +28,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `contents` - The raw loadavg info 

--- a/content/api/support-bundle-yaml-specs/os-loadavg.md
+++ b/content/api/support-bundle-yaml-specs/os-loadavg.md
@@ -20,23 +20,23 @@ specs:
       output_dir: /system/load
 ```
 
-    
+
 ### Optional Parameters
 
 
 - `template` - (Optional) a template for the human-readable output
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `contents` - The raw loadavg info 
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/os-read-file.md
+++ b/content/api/support-bundle-yaml-specs/os-read-file.md
@@ -29,7 +29,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `bigtool.conf` - The file contents

--- a/content/api/support-bundle-yaml-specs/os-read-file.md
+++ b/content/api/support-bundle-yaml-specs/os-read-file.md
@@ -21,23 +21,23 @@ specs:
       filepath: /etc/bigtool.conf
 ```
 
-    
+
 ### Required Parameters
 
 
 - `filepath` - The file path on the host. If running Support Bundle via docker, this will work, but symlinks are not supported
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `bigtool.conf` - The file contents
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/os-run-command.md
+++ b/content/api/support-bundle-yaml-specs/os-run-command.md
@@ -51,7 +51,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `stderr` - The standard error of the command

--- a/content/api/support-bundle-yaml-specs/os-run-command.md
+++ b/content/api/support-bundle-yaml-specs/os-run-command.md
@@ -30,14 +30,14 @@ specs:
         - /etc/os-release
 ```
 
-    
+
 ### Required Parameters
 
 
 - `name` - The command to run
 
 
-    
+
 ### Optional Parameters
 
 
@@ -50,18 +50,18 @@ specs:
 - `env` - Specifies additional environment variables
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `stderr` - The standard error of the command
 
 - `stdout` - The standard output of the command
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/os-uptime.md
+++ b/content/api/support-bundle-yaml-specs/os-uptime.md
@@ -28,7 +28,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `contents` - The contents of the uptime file

--- a/content/api/support-bundle-yaml-specs/os-uptime.md
+++ b/content/api/support-bundle-yaml-specs/os-uptime.md
@@ -20,23 +20,23 @@ specs:
       output_dir: /system/uptime
 ```
 
-    
+
 ### Optional Parameters
 
 
 - `template` - Template for the human-readable output
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `contents` - The contents of the uptime file
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/retraced-events.md
+++ b/content/api/support-bundle-yaml-specs/retraced-events.md
@@ -69,7 +69,7 @@ specs:
 
 
 
-    ### Outputs
+### Outputs
 
     
 - `audit_events.csv` - The audit events in CSV format

--- a/content/api/support-bundle-yaml-specs/retraced-events.md
+++ b/content/api/support-bundle-yaml-specs/retraced-events.md
@@ -42,7 +42,7 @@ specs:
         CRUD: 'c,u,d'
 ```
 
-    
+
 ### Required Parameters
 
 
@@ -55,7 +55,7 @@ specs:
 - `project_id` - The Audit Log Project ID
 
 
-    
+
 ### Optional Parameters
 
 
@@ -68,16 +68,16 @@ specs:
 - `query` - A structured query for filtering events, as in https://github.com/retracedhq/retraced-go/blob/master/graphql.go#L16
 
 
+
+    ### Outputs
+
     
-### Outputs
-
-
 - `audit_events.csv` - The audit events in CSV format
 
-    
+
 <br>
 {{< note title="Shared Parameters" >}}
 This spec also inherits all of the required and optional [Shared Parameters](/api/support-bundle-yaml-specs/shared/)
 {{< /note >}}
-    
+
     

--- a/content/api/support-bundle-yaml-specs/shared.md
+++ b/content/api/support-bundle-yaml-specs/shared.md
@@ -28,6 +28,8 @@ information you want to collect to debug your application. All Support Bundle sp
 
 - `meta` - A `name` and `labels` that can be used to organize and identify support bundle elements in generated bundles
 
+- `include_empty` - Allows empty files to be included in output
+
 ### Usage
 
 An example is shown below for the `os.read-file` collector.
@@ -53,5 +55,6 @@ specs:
         labels:
           area: "configuration"
           type: "readfile"
+      # Includes file in output even if empty
+      include_empty: true
 ```
-


### PR DESCRIPTION
This PR updates shared spec documentation with new field `include_empty`. Some additional changes were made to how these files are generated, hence the larger diff.