### PR TITLE
Replicated Studio Guide

### DIFF
--- a/content/guides/iterate-with-replicated-studio/configure.md
+++ b/content/guides/iterate-with-replicated-studio/configure.md
@@ -4,7 +4,7 @@ title: "Configure Replicated to Use Studio"
 description: "Install Replicated and configure it to use Studio"
 weight: "9012"
 categories: [ "Replicated Studio Guide" ]
-index: "guides/ship"
+index: "guides/studio"
 type: "chapter"
 gradient: "redToRed"
 icon: "replicatedCircle"

--- a/content/guides/iterate-with-replicated-studio/configure.md
+++ b/content/guides/iterate-with-replicated-studio/configure.md
@@ -1,0 +1,34 @@
+---
+date: "2018-05-25T12:00:00Z"
+title: "Configure Replicated to Use Studio"
+description: "Install Replicated and configure it to use Studio"
+weight: "9012"
+categories: [ "Replicated Studio Guide" ]
+index: "guides/ship"
+type: "chapter"
+gradient: "redToRed"
+icon: "replicatedCircle"
+aliases: [/guides/configure-studio]
+---
+
+### Install Replicated with Studio configuration on the dev server
+
+Use our simple installation script (on a Linux server in your IaaS provider of choice, or in a local dev environment in Vagrant/VirtualBox) to install Replicated. You'll be prompted for the ngrok hostname provided earlier during setup.
+
+#### Native
+
+```bash
+curl -sSL https://get.replicated.com/studio/native | sudo bash
+```
+
+#### Swarm
+
+```bash
+curl -sSL https://get.replicated.com/studio/swarm  | sudo bash
+```
+
+#### Kubernetes
+
+```bash
+curl -sSL https://get.replicated.com/studio/k8s | sudo bash
+```

--- a/content/guides/iterate-with-replicated-studio/index.md
+++ b/content/guides/iterate-with-replicated-studio/index.md
@@ -6,9 +6,9 @@
   gradient: "redToRed"
   index: false
   chapters:
-    - title: "Why Should I Use Studio?"
+    - title: "Intro to Studio"
       description: "What Replicated Studio is good for and why you might want to use it"
-      slug: "why-studio" 
+      slug: "intro-to-studio"
     - title: "Install Replicated Studio and ngrok"
       description: "Setup Replicated Studio on your local machine"
       slug: "setup-studio"

--- a/content/guides/iterate-with-replicated-studio/index.md
+++ b/content/guides/iterate-with-replicated-studio/index.md
@@ -1,0 +1,18 @@
+---
+  title: "Iterating on an an Application With Replicated Studio"
+  description: "A step-by-step guide to setting up Replicated Studio as a prototyping environment for your Replicated releases."
+  level: "replicatedCircle"
+  icon: "replicatedCircle"
+  gradient: "redToRed"
+  index: false
+  chapters:
+    - title: "Install Replicated Studio and ngrok"
+      description: "Setup Replicated Studio on your local machine"
+      slug: "setup-studio"
+    - title: "Configure Replicated to Use Studio"
+      description: "Install Replicated and configure it to use Studio"
+      slug: "configure"
+    - title: "Iterate and Test Updates"
+      description: "Use Studio to Make Prototyping Easier"
+      slug: "iterate"
+---

--- a/content/guides/iterate-with-replicated-studio/index.md
+++ b/content/guides/iterate-with-replicated-studio/index.md
@@ -6,6 +6,9 @@
   gradient: "redToRed"
   index: false
   chapters:
+    - title: "Why Should I Use Studio?"
+      description: "What Replicated Studio is good for and why you might want to use it"
+      slug: "why-studio" 
     - title: "Install Replicated Studio and ngrok"
       description: "Setup Replicated Studio on your local machine"
       slug: "setup-studio"

--- a/content/guides/iterate-with-replicated-studio/intro-to-studio.md
+++ b/content/guides/iterate-with-replicated-studio/intro-to-studio.md
@@ -1,14 +1,14 @@
 ---
 date: "2018-05-25T12:00:00Z"
-title: "Why Should I Use Replicated Studio"
+title: "Intro to Studio"
 description: "What Replicated Studio is, what it does, and why you should use it"
 weight: "9010"
 categories: [ "Replicated Studio Guide" ]
-index: "guides/ship"
+index: "guides/studio"
 type: "chapter"
 gradient: "redToRed"
 icon: "replicatedCircle"
-aliases: [/guides/why-studio]
+aliases: [/guides/intro-to-studio]
 ---
 
 In order to get your application working with Replicated, you'll want to set up a simple environment to iterate on your Replicated YAML and images. Our Replicated Studio is designed to shorten the cycle between writing and testing YAML and will recommend best practices to help you solve problems quickly.

--- a/content/guides/iterate-with-replicated-studio/iterate.md
+++ b/content/guides/iterate-with-replicated-studio/iterate.md
@@ -1,0 +1,43 @@
+---
+date: "2018-05-25T12:00:00Z"
+title: "Iterate and Test Updates"
+description: "A guide to walk you through iterating and updating a release in Replicated"
+weight: "9013"
+categories: [ "Replicated Studio Guide" ]
+index: "guides/studio"
+type: "chapter"
+gradient: "redToRed"
+icon: "replicatedCircle"
+aliases: [/guides/iterate-studio]
+---
+
+{{< linked_headline "Iterate on your application YAML" >}}
+
+During Studio installation on your local development machine, a new directory named `replicated` is created in your home directory. Once your license is activated, Replicated Studio will set up the most recent release and save it to `~/replicated/current.yaml`. Any time this file is updated and saved, Replicated Studio will create a new release using the next available sequence number. To start you'll probably want to copy and paste your most recent yaml as the downloading process often adds in default `null` values.
+
+From there you can use your favorite editor locally (like Atom, Visual Studio Code, Vim, or Emacs) and saved changes will trigger new updates available to your development server.
+
+**_Note: In the directory `~/replicated/releases/` you can view a copy of each release Replicated Studio has created along the way._**
+If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` save a new version of `current.yaml`.
+
+### Applying updates to the dev server
+
+After you have saved your `current.yaml` changes, you can navigate to your on-prem Admin Console (`https://<YOUR SERVER ADDRESS>:8800`) and click the `Check for updates` button to see your new release.
+
+{{< linked_headline "Iterate on your Application Images" >}}
+
+As well as being able to iterate on your application YAML, you can also use Studio to iterate on your Docker images. This simplifies the development workflow when you need to make changes to your code base to support on-prem deployments.
+
+To do this, rebuild your Docker images on your Studio server reusing the existing tags. Once you restart the application from the on-prem Admin Console (`https://<YOUR SERVER ADDRESS>:8800`) or CLI, your updated images will be used by Replicated.
+
+**_Note: When iterating on Docker images in Studio, referencing local Docker images using the `latest` tag is not supported. Replicated will re-pull any images with the `latest` tag, thus overwriting any changes you are making locally._**
+
+{{< linked_headline "Additional features" >}}
+
+The logs from Replicated Studio display any lint or syntax issues detected in your application yaml. You can also view all interactions the on-prem Replicated has with the Studio API.
+
+You can follow these logs in real time using:
+
+```bash
+docker logs -f studio
+```

--- a/content/guides/iterate-with-replicated-studio/setup-studio.md
+++ b/content/guides/iterate-with-replicated-studio/setup-studio.md
@@ -1,0 +1,46 @@
+---
+date: "2018-05-25T12:00:00Z"
+title: "Install Replicated Studio and ngrok"
+description: "Setup Replicated Studio on your local machine"
+weight: "9011"
+categories: [ "Replicated Studio Guide" ]
+index: "guides/ship"
+type: "chapter"
+gradient: "redToRed"
+icon: "replicatedCircle"
+aliases: [/guides/setup-studio]
+---
+
+In order to get your application working with Replicated, you'll want to set up a simple environment to iterate on your Replicated YAML and images. Our Replicated Studio is designed to shorten the cycle between writing and testing YAML and will recommend best practices to help you solve problems quickly.
+
+{{< linked_headline "Install Replicated Studio (with ngrok)" >}}
+
+### 1. Run Replicated Studio on your local dev machine
+You'll need [Docker installed](https://www.docker.com/community-edition) on your local development machine.
+
+```bash
+mkdir -p $HOME/replicated
+
+docker run --name studio -d \
+    --restart always \
+    -v $HOME/replicated:/replicated \
+    -p 8006:8006 \
+    replicated/studio:latest
+```
+
+### 2. Install ngrok
+
+Since we're developing locally, we'll need to expose our local development environment to the internet, so that changes you make to `current.yaml` in your `replicated` directory can be served to your development server.
+
+Download and install [ngrok from the official site](https://ngrok.com/download) (you'll need to create an account as well.)
+
+When you're done with that, you can expose your localhost by running `./ngrok http 8006` on the command line. You should see a line that looks something like this:
+
+`Forwarding    https://a23glmnop.ngrok.io -> 127.0.0.1:8006`
+Copy that *.ngrok.io* URL, you'll need it when you install Replicated on the development server.
+
+{{< linked_headline "Install Replicated Studio (without ngrok)" >}}
+
+It is also possible to use Replicated Studio without ngrok. This requires Replicated Studio to run on the same server as the Replicated instance you're debugging with. Instructions can be found at these links for [Native](https://help.replicated.com/community/t/iterating-on-yaml-with-studio-without-ngrok/150/2), [Swarm](https://help.replicated.com/community/t/using-studio-without-ngrok-docker-swarm/149/2) and [Kubernetes](https://help.replicated.com/community/t/using-studio-without-ngrok-kubernetes/148/2).
+
+You'll use `http://127.0.0.1:8006` instead of an ngrok hostname when installing Replicated.

--- a/content/guides/iterate-with-replicated-studio/setup-studio.md
+++ b/content/guides/iterate-with-replicated-studio/setup-studio.md
@@ -4,7 +4,7 @@ title: "Install Replicated Studio and ngrok"
 description: "Setup Replicated Studio on your local machine"
 weight: "9011"
 categories: [ "Replicated Studio Guide" ]
-index: "guides/ship"
+index: "guides/studio"
 type: "chapter"
 gradient: "redToRed"
 icon: "replicatedCircle"

--- a/content/guides/iterate-with-replicated-studio/setup-studio.md
+++ b/content/guides/iterate-with-replicated-studio/setup-studio.md
@@ -11,8 +11,6 @@ icon: "replicatedCircle"
 aliases: [/guides/setup-studio]
 ---
 
-In order to get your application working with Replicated, you'll want to set up a simple environment to iterate on your Replicated YAML and images. Our Replicated Studio is designed to shorten the cycle between writing and testing YAML and will recommend best practices to help you solve problems quickly.
-
 {{< linked_headline "Install Replicated Studio (with ngrok)" >}}
 
 ### 1. Run Replicated Studio on your local dev machine

--- a/content/guides/iterate-with-replicated-studio/why-studio.md
+++ b/content/guides/iterate-with-replicated-studio/why-studio.md
@@ -1,0 +1,16 @@
+---
+date: "2018-05-25T12:00:00Z"
+title: "Why Should I Use Replicated Studio"
+description: "What Replicated Studio is, what it does, and why you should use it"
+weight: "9010"
+categories: [ "Replicated Studio Guide" ]
+index: "guides/ship"
+type: "chapter"
+gradient: "redToRed"
+icon: "replicatedCircle"
+aliases: [/guides/why-studio]
+---
+
+In order to get your application working with Replicated, you'll want to set up a simple environment to iterate on your Replicated YAML and images. Our Replicated Studio is designed to shorten the cycle between writing and testing YAML and will recommend best practices to help you solve problems quickly.
+
+Replicated Studio is designed to allow you to make changes to a local file and have those changes immediately available to a Replicated instance running on a remote server. This is done by running a replacement for the Replicated APIs on your device that proxies most requests to the actual Replicated API while serving requests for the application yaml from the files stored locally on your computer. This allows you to create releases that are visible to your test installation without having to go through vendor.replicated.com or the [Replicated Vendor API](https://help.replicated.com/api/vendor-api/). To do this, Replicated Studio watches a file `~/replicated/current.yaml` and publishes a new release every time the file is modified. Studio is exposed to the remote Replicated installation with [ngrok](https://ngrok.com/).


### PR DESCRIPTION
This is basically copied from the docs version - the main changes are that it was split into 3 parts, that the installation instructions for all three schedulers are included, and there are links to the community posts describing the setup for non-ngrok Studio.