### PR TITLE
update replicatedctl docs with latest generated versions

### DIFF
--- a/content/api/replicatedctl.md
+++ b/content/api/replicatedctl.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl
 categories:
 - Reference
+date: 2018-06-22T16:37:46-07:00
 description: Documentation for the replicatedctl command line
-date: 2018-02-13T18:09:21Z
+gradient: purpleToPink
 index: docs
 title: replicatedctl Reference
 weight: "505"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl
@@ -16,7 +16,6 @@ gradient: "purpleToPink"
 Replicated CLI
 
 ### Synopsis
-
 
 Replicated is a platform to deploy containerized SaaS applications behind a firewall (ie private cloud, private data center etc).
 
@@ -27,17 +26,19 @@ replicatedctl
 ### Options
 
 ```
+  -h, --help          help for replicatedctl
       --host string   Replicated API host (default "unix:///var/run/replicated/replicated-cli.sock")
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app](/api/replicatedctl/replicatedctl_app/)	 - Manage apps
 * [replicatedctl app-config](/api/replicatedctl/replicatedctl_app-config/)	 - Manage app config
 * [replicatedctl app-release](/api/replicatedctl/replicatedctl_app-release/)	 - Manage app releases
 * [replicatedctl console-auth](/api/replicatedctl/replicatedctl_console-auth/)	 - Manage UI console authentication settings
 * [replicatedctl license](/api/replicatedctl/replicatedctl_license/)	 - Manage the license
 * [replicatedctl license-load](/api/replicatedctl/replicatedctl_license-load/)	 - Load the license from stdin
-* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage params
+* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 * [replicatedctl preflight](/api/replicatedctl/replicatedctl_preflight/)	 - View or manage preflight checks
 * [replicatedctl snapshot](/api/replicatedctl/replicatedctl_snapshot/)	 - Manage snapshots
 * [replicatedctl support-bundle](/api/replicatedctl/replicatedctl_support-bundle/)	 - Generate a support bundle

--- a/content/api/replicatedctl/replicatedctl_app-config.md
+++ b/content/api/replicatedctl/replicatedctl_app-config.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-config
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage app config
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-config
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-config
@@ -17,8 +17,13 @@ Manage app config
 
 ### Synopsis
 
-
 Manage app config
+
+### Options
+
+```
+  -h, --help   help for app-config
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage app config
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl app-config export](/api/replicatedctl/replicatedctl_app-config_export/)	 - Export app config settings
 * [replicatedctl app-config import](/api/replicatedctl/replicatedctl_app-config_import/)	 - Import app config settings from stdin

--- a/content/api/replicatedctl/replicatedctl_app-config_export.md
+++ b/content/api/replicatedctl/replicatedctl_app-config_export.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-config_export
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Export app config settings
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-config export
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-config export
@@ -17,16 +17,16 @@ Export app config settings
 
 ### Synopsis
 
-
 Export app config settings
 
 ```
-replicatedctl app-config export
+replicatedctl app-config export [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for export
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
 ```
@@ -38,5 +38,6 @@ replicatedctl app-config export
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-config](/api/replicatedctl/replicatedctl_app-config/)	 - Manage app config
 

--- a/content/api/replicatedctl/replicatedctl_app-config_import.md
+++ b/content/api/replicatedctl/replicatedctl_app-config_import.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-config_import
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Import app config settings from stdin
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-config import
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-config import
@@ -17,17 +17,17 @@ Import app config settings from stdin
 
 ### Synopsis
 
-
 Import app config settings from stdin
 
 ```
-replicatedctl app-config import
+replicatedctl app-config import [flags]
 ```
 
 ### Options
 
 ```
       --format string   Input format. One of: json|yaml (default "json")
+  -h, --help            help for import
 ```
 
 ### Options inherited from parent commands
@@ -37,5 +37,6 @@ replicatedctl app-config import
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-config](/api/replicatedctl/replicatedctl_app-config/)	 - Manage app config
 

--- a/content/api/replicatedctl/replicatedctl_app-config_set.md
+++ b/content/api/replicatedctl/replicatedctl_app-config_set.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-config_set
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Sets an individual app config value
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-config set
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-config set
@@ -17,18 +17,18 @@ Sets an individual app config value
 
 ### Synopsis
 
-
 Sets an individual app config value
 
 ```
-replicatedctl app-config set NAME
+replicatedctl app-config set NAME [flags]
 ```
 
 ### Options
 
 ```
-      --data stringSlice    Sets the item data
-      --value stringSlice   Sets the item value
+      --data strings    Sets the item data
+  -h, --help            help for set
+      --value strings   Sets the item value
 ```
 
 ### Options inherited from parent commands
@@ -38,5 +38,6 @@ replicatedctl app-config set NAME
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-config](/api/replicatedctl/replicatedctl_app-config/)	 - Manage app config
 

--- a/content/api/replicatedctl/replicatedctl_app-config_view.md
+++ b/content/api/replicatedctl/replicatedctl_app-config_view.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-config_view
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: View app config form
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-config view
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-config view
@@ -17,17 +17,17 @@ View app config form
 
 ### Synopsis
 
-
 View app config form
 
 ```
-replicatedctl app-config view
+replicatedctl app-config view [flags]
 ```
 
 ### Options
 
 ```
       --group string      Config group to filter by
+  -h, --help              help for view
   -o, --output string     Output format. One of: json|yaml
   -q, --quiet             Only display IDs
       --template string   Format the output using the given Go template
@@ -40,5 +40,6 @@ replicatedctl app-config view
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-config](/api/replicatedctl/replicatedctl_app-config/)	 - Manage app config
 

--- a/content/api/replicatedctl/replicatedctl_app-release.md
+++ b/content/api/replicatedctl/replicatedctl_app-release.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-release
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage app releases
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-release
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-release
@@ -17,8 +17,13 @@ Manage app releases
 
 ### Synopsis
 
-
 Manage app releases
+
+### Options
+
+```
+  -h, --help   help for app-release
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage app releases
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl app-release apply](/api/replicatedctl/replicatedctl_app-release_apply/)	 - Applies pending app releases
 * [replicatedctl app-release inspect](/api/replicatedctl/replicatedctl_app-release_inspect/)	 - Display detailed information on one or more app releases

--- a/content/api/replicatedctl/replicatedctl_app-release_apply.md
+++ b/content/api/replicatedctl/replicatedctl_app-release_apply.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-release_apply
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Applies pending app releases
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-release apply
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-release apply
@@ -17,17 +17,17 @@ Applies pending app releases
 
 ### Synopsis
 
-
 Applies pending app releases
 
 ```
-replicatedctl app-release apply
+replicatedctl app-release apply [flags]
 ```
 
 ### Options
 
 ```
   -a, --attach            Attach to task
+  -h, --help              help for apply
   -q, --quiet             Only display task ID
       --raw               Raw JSON stream
       --sequence int      Apply releases up to and including specified sequence (0 for all)
@@ -41,5 +41,6 @@ replicatedctl app-release apply
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-release](/api/replicatedctl/replicatedctl_app-release/)	 - Manage app releases
 

--- a/content/api/replicatedctl/replicatedctl_app-release_inspect.md
+++ b/content/api/replicatedctl/replicatedctl_app-release_inspect.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-release_inspect
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Display detailed information on one or more app releases
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-release inspect
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-release inspect
@@ -17,16 +17,16 @@ Display detailed information on one or more app releases
 
 ### Synopsis
 
-
 Display detailed information on one or more app releases
 
 ```
-replicatedctl app-release inspect SEQUENCE [SEQUENCE...]
+replicatedctl app-release inspect SEQUENCE [SEQUENCE...] [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for inspect
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
 ```
@@ -38,5 +38,6 @@ replicatedctl app-release inspect SEQUENCE [SEQUENCE...]
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-release](/api/replicatedctl/replicatedctl_app-release/)	 - Manage app releases
 

--- a/content/api/replicatedctl/replicatedctl_app-release_ls.md
+++ b/content/api/replicatedctl/replicatedctl_app-release_ls.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-release_ls
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: List app releases
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-release ls
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-release ls
@@ -17,18 +17,18 @@ List app releases
 
 ### Synopsis
 
-
 List app releases
 
 ```
-replicatedctl app-release ls
+replicatedctl app-release ls [flags]
 ```
 
 ### Options
 
 ```
       --all               Display all app releases
-      --fetch             Fetch releases form Market API
+      --fetch             Fetch releases from the cloud
+  -h, --help              help for ls
   -o, --output string     Output format. One of: json|yaml
       --pending           Display only pending app releases
   -q, --quiet             Only display IDs
@@ -42,5 +42,6 @@ replicatedctl app-release ls
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-release](/api/replicatedctl/replicatedctl_app-release/)	 - Manage app releases
 

--- a/content/api/replicatedctl/replicatedctl_app-release_notes.md
+++ b/content/api/replicatedctl/replicatedctl_app-release_notes.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app-release_notes
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Display release notes for an app releases
+gradient: purpleToPink
 index: docs
 title: replicatedctl app-release notes
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app-release notes
@@ -17,11 +17,16 @@ Display release notes for an app releases
 
 ### Synopsis
 
-
 Display release notes for an app releases
 
 ```
-replicatedctl app-release notes SEQUENCE
+replicatedctl app-release notes SEQUENCE [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for notes
 ```
 
 ### Options inherited from parent commands
@@ -31,5 +36,6 @@ replicatedctl app-release notes SEQUENCE
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app-release](/api/replicatedctl/replicatedctl_app-release/)	 - Manage app releases
 

--- a/content/api/replicatedctl/replicatedctl_app.md
+++ b/content/api/replicatedctl/replicatedctl_app.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage apps
+gradient: purpleToPink
 index: docs
 title: replicatedctl app
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app
@@ -17,8 +17,13 @@ Manage apps
 
 ### Synopsis
 
-
 Manage apps
+
+### Options
+
+```
+  -h, --help   help for app
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage apps
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl app inspect](/api/replicatedctl/replicatedctl_app_inspect/)	 - Display detailed information on the app
 * [replicatedctl app start](/api/replicatedctl/replicatedctl_app_start/)	 - Start the app

--- a/content/api/replicatedctl/replicatedctl_app_inspect.md
+++ b/content/api/replicatedctl/replicatedctl_app_inspect.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app_inspect
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Display detailed information on the app
+gradient: purpleToPink
 index: docs
 title: replicatedctl app inspect
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app inspect
@@ -17,16 +17,16 @@ Display detailed information on the app
 
 ### Synopsis
 
-
 Display detailed information on the app
 
 ```
-replicatedctl app inspect
+replicatedctl app inspect [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for inspect
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
 ```
@@ -38,5 +38,6 @@ replicatedctl app inspect
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app](/api/replicatedctl/replicatedctl_app/)	 - Manage apps
 

--- a/content/api/replicatedctl/replicatedctl_app_start.md
+++ b/content/api/replicatedctl/replicatedctl_app_start.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app_start
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Start the app
+gradient: purpleToPink
 index: docs
 title: replicatedctl app start
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app start
@@ -17,17 +17,17 @@ Start the app
 
 ### Synopsis
 
-
 Start the app
 
 ```
-replicatedctl app start
+replicatedctl app start [flags]
 ```
 
 ### Options
 
 ```
   -a, --attach            Attach to task
+  -h, --help              help for start
   -q, --quiet             Only display task ID
       --raw               Raw JSON stream
       --template string   Format the output using the given Go template
@@ -40,5 +40,6 @@ replicatedctl app start
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app](/api/replicatedctl/replicatedctl_app/)	 - Manage apps
 

--- a/content/api/replicatedctl/replicatedctl_app_status.md
+++ b/content/api/replicatedctl/replicatedctl_app_status.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app_status
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage the app status
+gradient: purpleToPink
 index: docs
 title: replicatedctl app status
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app status
@@ -17,8 +17,13 @@ Manage the app status
 
 ### Synopsis
 
-
 Manage the app status
+
+### Options
+
+```
+  -h, --help   help for status
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage the app status
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app](/api/replicatedctl/replicatedctl_app/)	 - Manage apps
 * [replicatedctl app status inspect](/api/replicatedctl/replicatedctl_app_status_inspect/)	 - Display detailed information on the app's status
 

--- a/content/api/replicatedctl/replicatedctl_app_status_inspect.md
+++ b/content/api/replicatedctl/replicatedctl_app_status_inspect.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app_status_inspect
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Display detailed information on the app's status
+gradient: purpleToPink
 index: docs
 title: replicatedctl app status inspect
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app status inspect
@@ -17,16 +17,16 @@ Display detailed information on the app's status
 
 ### Synopsis
 
-
 Display detailed information on the app's status
 
 ```
-replicatedctl app status inspect
+replicatedctl app status inspect [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for inspect
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
 ```
@@ -38,5 +38,6 @@ replicatedctl app status inspect
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app status](/api/replicatedctl/replicatedctl_app_status/)	 - Manage the app status
 

--- a/content/api/replicatedctl/replicatedctl_app_stop.md
+++ b/content/api/replicatedctl/replicatedctl_app_stop.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_app_stop
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Stop the app
+gradient: purpleToPink
 index: docs
 title: replicatedctl app stop
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl app stop
@@ -17,11 +17,10 @@ Stop the app
 
 ### Synopsis
 
-
 Stop the app
 
 ```
-replicatedctl app stop
+replicatedctl app stop [flags]
 ```
 
 ### Options
@@ -29,6 +28,7 @@ replicatedctl app stop
 ```
   -a, --attach            Attach to task
   -f, --force             Force stop
+  -h, --help              help for stop
   -q, --quiet             Only display task ID
       --raw               Raw JSON stream
       --template string   Format the output using the given Go template
@@ -41,5 +41,6 @@ replicatedctl app stop
 ```
 
 ### SEE ALSO
+
 * [replicatedctl app](/api/replicatedctl/replicatedctl_app/)	 - Manage apps
 

--- a/content/api/replicatedctl/replicatedctl_console-auth.md
+++ b/content/api/replicatedctl/replicatedctl_console-auth.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_console-auth
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage UI console authentication settings
+gradient: purpleToPink
 index: docs
 title: replicatedctl console-auth
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl console-auth
@@ -17,8 +17,13 @@ Manage UI console authentication settings
 
 ### Synopsis
 
-
 Manage UI console authentication settings
+
+### Options
+
+```
+  -h, --help   help for console-auth
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage UI console authentication settings
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl console-auth export](/api/replicatedctl/replicatedctl_console-auth_export/)	 - Export console auth config for current auth type
 * [replicatedctl console-auth import](/api/replicatedctl/replicatedctl_console-auth_import/)	 - Import console authentication config from stdin

--- a/content/api/replicatedctl/replicatedctl_console-auth_export.md
+++ b/content/api/replicatedctl/replicatedctl_console-auth_export.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_console-auth_export
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Export console auth config for current auth type
+gradient: purpleToPink
 index: docs
 title: replicatedctl console-auth export
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl console-auth export
@@ -17,16 +17,16 @@ Export console auth config for current auth type
 
 ### Synopsis
 
-
 Export console auth config for current auth type
 
 ```
-replicatedctl console-auth export
+replicatedctl console-auth export [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for export
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
       --type string       Get configuration for auth type (one of anonymous, password, ldap)
@@ -39,5 +39,6 @@ replicatedctl console-auth export
 ```
 
 ### SEE ALSO
+
 * [replicatedctl console-auth](/api/replicatedctl/replicatedctl_console-auth/)	 - Manage UI console authentication settings
 

--- a/content/api/replicatedctl/replicatedctl_console-auth_import.md
+++ b/content/api/replicatedctl/replicatedctl_console-auth_import.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_console-auth_import
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Import console authentication config from stdin
+gradient: purpleToPink
 index: docs
 title: replicatedctl console-auth import
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl console-auth import
@@ -17,17 +17,17 @@ Import console authentication config from stdin
 
 ### Synopsis
 
-
 Import console authentication config from stdin
 
 ```
-replicatedctl console-auth import
+replicatedctl console-auth import [flags]
 ```
 
 ### Options
 
 ```
       --format string   Input format. One of: json|yaml (default "json")
+  -h, --help            help for import
 ```
 
 ### Options inherited from parent commands
@@ -37,5 +37,6 @@ replicatedctl console-auth import
 ```
 
 ### SEE ALSO
+
 * [replicatedctl console-auth](/api/replicatedctl/replicatedctl_console-auth/)	 - Manage UI console authentication settings
 

--- a/content/api/replicatedctl/replicatedctl_console-auth_reset.md
+++ b/content/api/replicatedctl/replicatedctl_console-auth_reset.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_console-auth_reset
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Resets console authentication to type anonymous
+gradient: purpleToPink
 index: docs
 title: replicatedctl console-auth reset
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl console-auth reset
@@ -17,11 +17,16 @@ Resets console authentication to type anonymous
 
 ### Synopsis
 
-
 Resets console authentication to type anonymous
 
 ```
-replicatedctl console-auth reset
+replicatedctl console-auth reset [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for reset
 ```
 
 ### Options inherited from parent commands
@@ -31,5 +36,6 @@ replicatedctl console-auth reset
 ```
 
 ### SEE ALSO
+
 * [replicatedctl console-auth](/api/replicatedctl/replicatedctl_console-auth/)	 - Manage UI console authentication settings
 

--- a/content/api/replicatedctl/replicatedctl_license-load.md
+++ b/content/api/replicatedctl/replicatedctl_license-load.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_license-load
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Load the license from stdin
+gradient: purpleToPink
 index: docs
 title: replicatedctl license-load
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl license-load
@@ -17,17 +17,18 @@ Load the license from stdin
 
 ### Synopsis
 
-
 Load the license from stdin
 
 ```
-replicatedctl license-load
+replicatedctl license-load [flags]
 ```
 
 ### Options
 
 ```
   -a, --attach            Attach to task
+      --force-online      Force an online installation even when running in airgapped mode
+  -h, --help              help for license-load
   -q, --quiet             Only display task ID
       --raw               Raw JSON stream
       --template string   Format the output using the given Go template
@@ -40,5 +41,6 @@ replicatedctl license-load
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 

--- a/content/api/replicatedctl/replicatedctl_license.md
+++ b/content/api/replicatedctl/replicatedctl_license.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_license
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage the license
+gradient: purpleToPink
 index: docs
 title: replicatedctl license
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl license
@@ -17,8 +17,13 @@ Manage the license
 
 ### Synopsis
 
-
 Manage the license
+
+### Options
+
+```
+  -h, --help   help for license
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage the license
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl license activate](/api/replicatedctl/replicatedctl_license_activate/)	 - Activate the license
 * [replicatedctl license inspect](/api/replicatedctl/replicatedctl_license_inspect/)	 - Display detailed information on the license

--- a/content/api/replicatedctl/replicatedctl_license_activate.md
+++ b/content/api/replicatedctl/replicatedctl_license_activate.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_license_activate
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Activate the license
+gradient: purpleToPink
 index: docs
 title: replicatedctl license activate
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl license activate
@@ -17,17 +17,17 @@ Activate the license
 
 ### Synopsis
 
-
 Activate the license
 
 ```
-replicatedctl license activate CODE
+replicatedctl license activate CODE [flags]
 ```
 
 ### Options
 
 ```
   -a, --attach            Attach to task
+  -h, --help              help for activate
   -q, --quiet             Only display task ID
       --raw               Raw JSON stream
       --template string   Format the output using the given Go template
@@ -40,5 +40,6 @@ replicatedctl license activate CODE
 ```
 
 ### SEE ALSO
+
 * [replicatedctl license](/api/replicatedctl/replicatedctl_license/)	 - Manage the license
 

--- a/content/api/replicatedctl/replicatedctl_license_inspect.md
+++ b/content/api/replicatedctl/replicatedctl_license_inspect.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_license_inspect
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Display detailed information on the license
+gradient: purpleToPink
 index: docs
 title: replicatedctl license inspect
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl license inspect
@@ -17,16 +17,16 @@ Display detailed information on the license
 
 ### Synopsis
 
-
 Display detailed information on the license
 
 ```
-replicatedctl license inspect
+replicatedctl license inspect [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for inspect
   -o, --output string     Output format. One of: json|yaml
       --sync              Sync license
       --template string   Format the output using the given Go template
@@ -39,5 +39,6 @@ replicatedctl license inspect
 ```
 
 ### SEE ALSO
+
 * [replicatedctl license](/api/replicatedctl/replicatedctl_license/)	 - Manage the license
 

--- a/content/api/replicatedctl/replicatedctl_params.md
+++ b/content/api/replicatedctl/replicatedctl_params.md
@@ -3,22 +3,28 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_params
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
-description: Manage params
+date: 2018-06-22T16:37:46-07:00
+description: Manage Replicated daemon parameters. Provides the ability to import,
+  export, set and unset parameters.
+gradient: purpleToPink
 index: docs
 title: replicatedctl params
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl params
 
-Manage params
+Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 
 ### Synopsis
 
+Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 
-Manage params
+### Options
+
+```
+  -h, --help   help for params
+```
 
 ### Options inherited from parent commands
 
@@ -27,9 +33,10 @@ Manage params
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
-* [replicatedctl params export](/api/replicatedctl/replicatedctl_params_export/)	 - Export params
-* [replicatedctl params import](/api/replicatedctl/replicatedctl_params_import/)	 - Import params from stdin
-* [replicatedctl params set](/api/replicatedctl/replicatedctl_params_set/)	 - Sets an individual param value
-* [replicatedctl params unset](/api/replicatedctl/replicatedctl_params_unset/)	 - Unsets a runtime overridden param value
+* [replicatedctl params export](/api/replicatedctl/replicatedctl_params_export/)	 - Export Replicated daemon parameters to stdout
+* [replicatedctl params import](/api/replicatedctl/replicatedctl_params_import/)	 - Import Replicated parameters from stdin
+* [replicatedctl params set](/api/replicatedctl/replicatedctl_params_set/)	 - Sets an individual Replicated daemon parameter value
+* [replicatedctl params unset](/api/replicatedctl/replicatedctl_params_unset/)	 - Unsets a runtime overridden Replicated daemon parameter value
 

--- a/content/api/replicatedctl/replicatedctl_params_export.md
+++ b/content/api/replicatedctl/replicatedctl_params_export.md
@@ -3,30 +3,37 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_params_export
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
-description: Export params
+date: 2018-06-22T16:37:46-07:00
+description: Export Replicated daemon parameters to stdout
+gradient: purpleToPink
 index: docs
 title: replicatedctl params export
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl params export
 
-Export params
+Export Replicated daemon parameters to stdout
 
 ### Synopsis
 
-
-Export params
+Export Replicated daemon parameters to stdout
 
 ```
-replicatedctl params export
+replicatedctl params export [flags]
+```
+
+### Examples
+
+```
+replicatedctl params export --output yaml > params.yaml
+replicatedctl params export --template '{{.AppUpdateCheckSchedule}}'
 ```
 
 ### Options
 
 ```
+  -h, --help              help for export
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
 ```
@@ -38,5 +45,6 @@ replicatedctl params export
 ```
 
 ### SEE ALSO
-* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage params
+
+* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 

--- a/content/api/replicatedctl/replicatedctl_params_import.md
+++ b/content/api/replicatedctl/replicatedctl_params_import.md
@@ -3,31 +3,37 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_params_import
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
-description: Import params from stdin
+date: 2018-06-22T16:37:46-07:00
+description: Import Replicated parameters from stdin
+gradient: purpleToPink
 index: docs
 title: replicatedctl params import
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl params import
 
-Import params from stdin
+Import Replicated parameters from stdin
 
 ### Synopsis
 
-
-Import params from stdin
+Import Replicated parameters from stdin
 
 ```
-replicatedctl params import
+replicatedctl params import [flags]
+```
+
+### Examples
+
+```
+replicatedctl params import --format yaml < params.yaml
 ```
 
 ### Options
 
 ```
       --format string   Input format. One of: json|yaml (default "json")
+  -h, --help            help for import
 ```
 
 ### Options inherited from parent commands
@@ -37,5 +43,6 @@ replicatedctl params import
 ```
 
 ### SEE ALSO
-* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage params
+
+* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 

--- a/content/api/replicatedctl/replicatedctl_params_set.md
+++ b/content/api/replicatedctl/replicatedctl_params_set.md
@@ -3,30 +3,36 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_params_set
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
-description: Sets an individual param value
+date: 2018-06-22T16:37:46-07:00
+description: Sets an individual Replicated daemon parameter value
+gradient: purpleToPink
 index: docs
 title: replicatedctl params set
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl params set
 
-Sets an individual param value
+Sets an individual Replicated daemon parameter value
 
 ### Synopsis
 
-
-Sets an individual param value
+Sets an individual Replicated daemon parameter value
 
 ```
-replicatedctl params set KEY
+replicatedctl params set KEY [flags]
+```
+
+### Examples
+
+```
+replicatedctl params set AppUpdateCheckSchedule --value '@every 5h'
 ```
 
 ### Options
 
 ```
+  -h, --help           help for set
       --value string   Sets the param value
 ```
 
@@ -37,5 +43,6 @@ replicatedctl params set KEY
 ```
 
 ### SEE ALSO
-* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage params
+
+* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 

--- a/content/api/replicatedctl/replicatedctl_params_unset.md
+++ b/content/api/replicatedctl/replicatedctl_params_unset.md
@@ -3,25 +3,36 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_params_unset
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
-description: Unsets a runtime overridden param value
+date: 2018-06-22T16:37:46-07:00
+description: Unsets a runtime overridden Replicated daemon parameter value
+gradient: purpleToPink
 index: docs
 title: replicatedctl params unset
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl params unset
 
-Unsets a runtime overridden param value
+Unsets a runtime overridden Replicated daemon parameter value
 
 ### Synopsis
 
-
-Unsets a runtime overridden param value
+Unsets a runtime overridden Replicated daemon parameter value
 
 ```
-replicatedctl params unset KEY
+replicatedctl params unset KEY [flags]
+```
+
+### Examples
+
+```
+replicatedctl params unset AppUpdateCheckSchedule
+```
+
+### Options
+
+```
+  -h, --help   help for unset
 ```
 
 ### Options inherited from parent commands
@@ -31,5 +42,6 @@ replicatedctl params unset KEY
 ```
 
 ### SEE ALSO
-* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage params
+
+* [replicatedctl params](/api/replicatedctl/replicatedctl_params/)	 - Manage Replicated daemon parameters. Provides the ability to import, export, set and unset parameters.
 

--- a/content/api/replicatedctl/replicatedctl_preflight.md
+++ b/content/api/replicatedctl/replicatedctl_preflight.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_preflight
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: View or manage preflight checks
+gradient: purpleToPink
 index: docs
 title: replicatedctl preflight
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl preflight
@@ -17,8 +17,13 @@ View or manage preflight checks
 
 ### Synopsis
 
-
 View or manage preflight checks
+
+### Options
+
+```
+  -h, --help   help for preflight
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ View or manage preflight checks
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl preflight dismiss](/api/replicatedctl/replicatedctl_preflight_dismiss/)	 - Dismiss preflight check warnings
 * [replicatedctl preflight run](/api/replicatedctl/replicatedctl_preflight_run/)	 - Run the preflight checks

--- a/content/api/replicatedctl/replicatedctl_preflight_dismiss.md
+++ b/content/api/replicatedctl/replicatedctl_preflight_dismiss.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_preflight_dismiss
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Dismiss preflight check warnings
+gradient: purpleToPink
 index: docs
 title: replicatedctl preflight dismiss
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl preflight dismiss
@@ -17,11 +17,10 @@ Dismiss preflight check warnings
 
 ### Synopsis
 
-
 Dismiss preflight check warnings
 
 ```
-replicatedctl preflight dismiss
+replicatedctl preflight dismiss [flags]
 ```
 
 ### Options
@@ -29,6 +28,7 @@ replicatedctl preflight dismiss
 ```
       --checksum string   Preflight checksum
   -f, --force             Force dismiss checks
+  -h, --help              help for dismiss
       --sequence string   App sequence (default "current")
 ```
 
@@ -39,5 +39,6 @@ replicatedctl preflight dismiss
 ```
 
 ### SEE ALSO
+
 * [replicatedctl preflight](/api/replicatedctl/replicatedctl_preflight/)	 - View or manage preflight checks
 

--- a/content/api/replicatedctl/replicatedctl_preflight_run.md
+++ b/content/api/replicatedctl/replicatedctl_preflight_run.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_preflight_run
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Run the preflight checks
+gradient: purpleToPink
 index: docs
 title: replicatedctl preflight run
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl preflight run
@@ -17,16 +17,16 @@ Run the preflight checks
 
 ### Synopsis
 
-
 Run the preflight checks
 
 ```
-replicatedctl preflight run
+replicatedctl preflight run [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for run
   -o, --output string     Output format. One of: json|yaml
   -q, --quiet             Only display checksum
       --sequence string   App sequence (default "current")
@@ -39,5 +39,6 @@ replicatedctl preflight run
 ```
 
 ### SEE ALSO
+
 * [replicatedctl preflight](/api/replicatedctl/replicatedctl_preflight/)	 - View or manage preflight checks
 

--- a/content/api/replicatedctl/replicatedctl_preflight_status.md
+++ b/content/api/replicatedctl/replicatedctl_preflight_status.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_preflight_status
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Get preflight status
+gradient: purpleToPink
 index: docs
 title: replicatedctl preflight status
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl preflight status
@@ -17,16 +17,16 @@ Get preflight status
 
 ### Synopsis
 
-
 Get preflight status
 
 ```
-replicatedctl preflight status
+replicatedctl preflight status [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for status
   -q, --quiet             Display true or false
       --sequence string   App sequence (default "current")
 ```
@@ -38,5 +38,6 @@ replicatedctl preflight status
 ```
 
 ### SEE ALSO
+
 * [replicatedctl preflight](/api/replicatedctl/replicatedctl_preflight/)	 - View or manage preflight checks
 

--- a/content/api/replicatedctl/replicatedctl_snapshot.md
+++ b/content/api/replicatedctl/replicatedctl_snapshot.md
@@ -3,8 +3,9 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_snapshot
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage snapshots
+gradient: purpleToPink
 index: docs
 title: replicatedctl snapshot
 weight: "551"
@@ -16,14 +17,15 @@ Manage snapshots
 
 ### Synopsis
 
-
 Manage snapshots
 
 ### Options
 
 ```
+  -h, --help                               help for snapshot
       --path string                        Snapshot location path. The value should be an absolute path. This option is only used with local and sftp backends.
       --s3-bucket string                   S3 bucket name. This option is only used with s3 backend.
+      --s3-compatible-endpoint string      AWS compatible S3 endpoint. This option is only used with s3 backend.
       --s3-key-id string                   ID of the secret key that has write access to the specified S3 bucket. This option is only used with s3 backend.
       --s3-region string                   S3 bucket region. This option is only used with s3 backend.
       --s3-secret-key string               Secret key value. This option is only used with s3 backend.
@@ -42,6 +44,7 @@ Manage snapshots
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl snapshot ls](/api/replicatedctl/replicatedctl_snapshot_ls/)	 - List snapshots
 * [replicatedctl snapshot restore](/api/replicatedctl/replicatedctl_snapshot_restore/)	 - Restore installation from the specified spanshot

--- a/content/api/replicatedctl/replicatedctl_snapshot_ls.md
+++ b/content/api/replicatedctl/replicatedctl_snapshot_ls.md
@@ -3,8 +3,9 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_snapshot_ls
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: List snapshots
+gradient: purpleToPink
 index: docs
 title: replicatedctl snapshot ls
 weight: "551"
@@ -16,16 +17,17 @@ List snapshots
 
 ### Synopsis
 
-
 List snapshots
 
 ```
-replicatedctl snapshot ls
+replicatedctl snapshot ls [flags]
 ```
 
 ### Options
 
 ```
+      --force-reload      Force snapshot server to restart and recover snapshot database
+  -h, --help              help for ls
   -o, --output string     Output format. One of: json|yaml
   -q, --quiet             Only display IDs
       --template string   Format the output using the given Go template
@@ -37,6 +39,7 @@ replicatedctl snapshot ls
       --host string                        Replicated API host (default "unix:///var/run/replicated/replicated-cli.sock")
       --path string                        Snapshot location path. The value should be an absolute path. This option is only used with local and sftp backends.
       --s3-bucket string                   S3 bucket name. This option is only used with s3 backend.
+      --s3-compatible-endpoint string      AWS compatible S3 endpoint. This option is only used with s3 backend.
       --s3-key-id string                   ID of the secret key that has write access to the specified S3 bucket. This option is only used with s3 backend.
       --s3-region string                   S3 bucket region. This option is only used with s3 backend.
       --s3-secret-key string               Secret key value. This option is only used with s3 backend.
@@ -49,5 +52,6 @@ replicatedctl snapshot ls
 ```
 
 ### SEE ALSO
+
 * [replicatedctl snapshot](/api/replicatedctl/replicatedctl_snapshot/)	 - Manage snapshots
 

--- a/content/api/replicatedctl/replicatedctl_snapshot_restore.md
+++ b/content/api/replicatedctl/replicatedctl_snapshot_restore.md
@@ -3,8 +3,9 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_snapshot_restore
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Restore installation from the specified spanshot
+gradient: purpleToPink
 index: docs
 title: replicatedctl snapshot restore
 weight: "551"
@@ -16,18 +17,17 @@ Restore installation from the specified spanshot
 
 ### Synopsis
 
-
 Restore installation from the specified spanshot
 
 ```
-replicatedctl snapshot restore ID
+replicatedctl snapshot restore ID [flags]
 ```
 
 ### Options
 
 ```
       --dismiss-preflight-checks   Dismiss preflight checks
-      --id string                  Snapshot ID
+  -h, --help                       help for restore
       --node-timeout int           Number of seconds to wait for nodes to connect (default 60)
 ```
 
@@ -37,6 +37,7 @@ replicatedctl snapshot restore ID
       --host string                        Replicated API host (default "unix:///var/run/replicated/replicated-cli.sock")
       --path string                        Snapshot location path. The value should be an absolute path. This option is only used with local and sftp backends.
       --s3-bucket string                   S3 bucket name. This option is only used with s3 backend.
+      --s3-compatible-endpoint string      AWS compatible S3 endpoint. This option is only used with s3 backend.
       --s3-key-id string                   ID of the secret key that has write access to the specified S3 bucket. This option is only used with s3 backend.
       --s3-region string                   S3 bucket region. This option is only used with s3 backend.
       --s3-secret-key string               Secret key value. This option is only used with s3 backend.
@@ -49,5 +50,6 @@ replicatedctl snapshot restore ID
 ```
 
 ### SEE ALSO
+
 * [replicatedctl snapshot](/api/replicatedctl/replicatedctl_snapshot/)	 - Manage snapshots
 

--- a/content/api/replicatedctl/replicatedctl_snapshot_start.md
+++ b/content/api/replicatedctl/replicatedctl_snapshot_start.md
@@ -3,8 +3,9 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_snapshot_start
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Start a snapshot
+gradient: purpleToPink
 index: docs
 title: replicatedctl snapshot start
 weight: "551"
@@ -16,17 +17,17 @@ Start a snapshot
 
 ### Synopsis
 
-
 Start a snapshot
 
 ```
-replicatedctl snapshot start
+replicatedctl snapshot start [flags]
 ```
 
 ### Options
 
 ```
       --exclude-app-data   Only backup Replicated data and exclude app data
+  -h, --help               help for start
       --wait               Block until snapshot is complete
 ```
 
@@ -36,6 +37,7 @@ replicatedctl snapshot start
       --host string                        Replicated API host (default "unix:///var/run/replicated/replicated-cli.sock")
       --path string                        Snapshot location path. The value should be an absolute path. This option is only used with local and sftp backends.
       --s3-bucket string                   S3 bucket name. This option is only used with s3 backend.
+      --s3-compatible-endpoint string      AWS compatible S3 endpoint. This option is only used with s3 backend.
       --s3-key-id string                   ID of the secret key that has write access to the specified S3 bucket. This option is only used with s3 backend.
       --s3-region string                   S3 bucket region. This option is only used with s3 backend.
       --s3-secret-key string               Secret key value. This option is only used with s3 backend.
@@ -48,5 +50,6 @@ replicatedctl snapshot start
 ```
 
 ### SEE ALSO
+
 * [replicatedctl snapshot](/api/replicatedctl/replicatedctl_snapshot/)	 - Manage snapshots
 

--- a/content/api/replicatedctl/replicatedctl_support-bundle.md
+++ b/content/api/replicatedctl/replicatedctl_support-bundle.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_support-bundle
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Generate a support bundle
+gradient: purpleToPink
 index: docs
 title: replicatedctl support-bundle
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl support-bundle
@@ -17,11 +17,16 @@ Generate a support bundle
 
 ### Synopsis
 
-
 Generate a support bundle
 
 ```
-replicatedctl support-bundle
+replicatedctl support-bundle [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for support-bundle
 ```
 
 ### Options inherited from parent commands
@@ -31,5 +36,6 @@ replicatedctl support-bundle
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 

--- a/content/api/replicatedctl/replicatedctl_task.md
+++ b/content/api/replicatedctl/replicatedctl_task.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_task
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Manage tasks
+gradient: purpleToPink
 index: docs
 title: replicatedctl task
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl task
@@ -17,8 +17,13 @@ Manage tasks
 
 ### Synopsis
 
-
 Manage tasks
+
+### Options
+
+```
+  -h, --help   help for task
+```
 
 ### Options inherited from parent commands
 
@@ -27,6 +32,7 @@ Manage tasks
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 * [replicatedctl task attach](/api/replicatedctl/replicatedctl_task_attach/)	 - Stream task progress
 * [replicatedctl task inspect](/api/replicatedctl/replicatedctl_task_inspect/)	 - Display detailed information on one or more tasks

--- a/content/api/replicatedctl/replicatedctl_task_attach.md
+++ b/content/api/replicatedctl/replicatedctl_task_attach.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_task_attach
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Stream task progress
+gradient: purpleToPink
 index: docs
 title: replicatedctl task attach
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl task attach
@@ -17,16 +17,16 @@ Stream task progress
 
 ### Synopsis
 
-
 Stream task progress
 
 ```
-replicatedctl task attach ID
+replicatedctl task attach ID [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for attach
   -q, --quiet             Suppress stdout
       --raw               Raw JSON stream
       --template string   Format the output using the given Go template
@@ -39,5 +39,6 @@ replicatedctl task attach ID
 ```
 
 ### SEE ALSO
+
 * [replicatedctl task](/api/replicatedctl/replicatedctl_task/)	 - Manage tasks
 

--- a/content/api/replicatedctl/replicatedctl_task_inspect.md
+++ b/content/api/replicatedctl/replicatedctl_task_inspect.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_task_inspect
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Display detailed information on one or more tasks
+gradient: purpleToPink
 index: docs
 title: replicatedctl task inspect
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl task inspect
@@ -17,16 +17,16 @@ Display detailed information on one or more tasks
 
 ### Synopsis
 
-
 Display detailed information on one or more tasks
 
 ```
-replicatedctl task inspect ID [ID...]
+replicatedctl task inspect ID [ID...] [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help              help for inspect
   -o, --output string     Output format. One of: json|yaml
       --template string   Format the output using the given Go template
 ```
@@ -38,5 +38,6 @@ replicatedctl task inspect ID [ID...]
 ```
 
 ### SEE ALSO
+
 * [replicatedctl task](/api/replicatedctl/replicatedctl_task/)	 - Manage tasks
 

--- a/content/api/replicatedctl/replicatedctl_task_ls.md
+++ b/content/api/replicatedctl/replicatedctl_task_ls.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_task_ls
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: List tasks
+gradient: purpleToPink
 index: docs
 title: replicatedctl task ls
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl task ls
@@ -17,17 +17,17 @@ List tasks
 
 ### Synopsis
 
-
 List tasks
 
 ```
-replicatedctl task ls
+replicatedctl task ls [flags]
 ```
 
 ### Options
 
 ```
       --all               Display all tasks
+  -h, --help              help for ls
   -o, --output string     Output format. One of: json|yaml
   -q, --quiet             Only display IDs
       --template string   Format the output using the given Go template
@@ -40,5 +40,6 @@ replicatedctl task ls
 ```
 
 ### SEE ALSO
+
 * [replicatedctl task](/api/replicatedctl/replicatedctl_task/)	 - Manage tasks
 

--- a/content/api/replicatedctl/replicatedctl_version.md
+++ b/content/api/replicatedctl/replicatedctl_version.md
@@ -3,12 +3,12 @@ aliases:
 - docs/reference/replicatedctl/replicatedctl_version
 categories:
 - replicatedctl
-date: 2018-02-20T00:45:55Z
+date: 2018-06-22T16:37:46-07:00
 description: Get the Replicated CLI version information
+gradient: purpleToPink
 index: docs
 title: replicatedctl version
 weight: "551"
-gradient: "purpleToPink"
 ---
 
 ## replicatedctl version
@@ -17,16 +17,16 @@ Get the Replicated CLI version information
 
 ### Synopsis
 
-
 Get the Replicated CLI version information
 
 ```
-replicatedctl version
+replicatedctl version [flags]
 ```
 
 ### Options
 
 ```
+  -h, --help    help for version
       --quiet   Only print the version
 ```
 
@@ -37,5 +37,6 @@ replicatedctl version
 ```
 
 ### SEE ALSO
+
 * [replicatedctl](/api/replicatedctl/)	 - Replicated CLI
 


### PR DESCRIPTION
replicatedctl.md has manual edits to bring it in line with previous version - autogeneration placed it within the replicatedctl folder