### PR TITLE
fix breaking .Site.GetPage calls to use single parameter

### DIFF
--- a/themes/replicated-docs-theme/layouts/_default/single.html
+++ b/themes/replicated-docs-theme/layouts/_default/single.html
@@ -41,7 +41,7 @@
 								<div class="prev-next-arrows justifyContent--spaceBetween flex u-marginTop--most">
 									<div class="next flex u-textAlign--left">
 										{{ if .Params.previousPage }}
-											{{ with .Site.GetPage "page" "docs" .Params.previousPage }}
+											{{ with .Site.GetPage .Params.previousPage }}
 											<a href="{{ .Permalink }}">
 												<span class="icon u-chevronIcon"></span>
 												{{ .Title }}
@@ -58,7 +58,7 @@
 										</div>
 										<div class="previous flex u-textAlign--right">
 										{{ if .Params.nextPage }}
-											{{ with .Site.GetPage "page" "docs" .Params.nextPage }}
+											{{ with .Site.GetPage .Params.nextPage }}
 											<a href="{{ .Permalink }}">
 												{{ .Title }}
 												<span class="icon u-chevronIcon"></span>

--- a/themes/replicated-docs-theme/layouts/partials/section_folder_navigation.html
+++ b/themes/replicated-docs-theme/layouts/partials/section_folder_navigation.html
@@ -59,7 +59,7 @@
             {{ if eq $scope "Native Scheduler" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-lineHeight--normal u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Replicated Native Scheduler</h3>
-                {{ with .Site.GetPage "section" "docs" "native" }}
+                {{ with .Site.GetPage "/docs/native" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -92,7 +92,7 @@
             {{ if eq $scope "Docker Swarm" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Swarm</h3>
-                {{ with .Site.GetPage "section" "docs" "swarm" }}
+                {{ with .Site.GetPage "/docs/swarm" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -125,7 +125,7 @@
             {{ if eq $scope "Kubernetes" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Kubernetes</h3>
-                {{ with .Site.GetPage "section" "docs" "kubernetes" }}
+                {{ with .Site.GetPage "/docs/kubernetes" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -158,7 +158,7 @@
             {{ if eq $category "Config Screen" }}
             <div class="u-marginBottom--most">
               <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Config Screen</h3>
-              {{ with .Site.GetPage "section" "docs" "config-screen" }}
+              {{ with .Site.GetPage "docs/config-screen" }}
                   {{ range .Pages }}
                       <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                           <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -191,7 +191,7 @@
             {{ if eq $category "Snapshots" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Snapshots</h3>
-                {{ with .Site.GetPage "section" "docs" "snapshots" }}
+                {{ with .Site.GetPage "/docs/snapshots" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -224,7 +224,7 @@
             {{ if eq $category "LDAP and Identity Integration" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">LDAP & Identity</h3>
-                {{ with .Site.GetPage "section" "docs" "ldap-and-identity" }}
+                {{ with .Site.GetPage "/docs/ldap-and-identity" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -257,7 +257,7 @@
             {{ if eq $category "Replicated Private Registry" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Private Registry</h3>
-                {{ with .Site.GetPage "section" "docs" "registry" }}
+                {{ with .Site.GetPage "/docs/registry" }}
                     {{ range .Pages }}
                         {{ if not .Params.hideFromList }}
                             <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
@@ -292,7 +292,7 @@
             {{ if eq $category "Vendor RBAC" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Vendor RBAC</h3>
-                {{ with .Site.GetPage "section" "docs" "vendor-rbac" }}
+                {{ with .Site.GetPage "/docs/vendor-rbac" }}
                     {{ range .Pages }}
                         {{ if not .Params.hideFromList }}
                             <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
@@ -327,7 +327,7 @@
             {{ if eq $scope "Audit Log" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Replicated Audit Log</h3>
-                {{ with .Site.GetPage "section" "docs" "audit-log" }}
+                {{ with .Site.GetPage "/docs/audit-log" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -360,7 +360,7 @@
             {{ if eq $scope "Ship" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Replicated Ship</h3>
-                {{ with .Site.GetPage "section" "docs" "ship" }}
+                {{ with .Site.GetPage "/docs/ship" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -393,7 +393,7 @@
             {{ if eq $scope "Troubleshoot" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Replicated Troubleshoot</h3>
-                {{ with .Site.GetPage "section" "docs" "troubleshoot" }}
+                {{ with .Site.GetPage "/docs/troubleshoot" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">
@@ -426,7 +426,7 @@
             {{ if eq $scope "Entitlements" }}
             <div class="u-marginBottom--most">
                 <h3 class="u-fontWeight--bold u-fontSize--large u-borderBottom--gray u-paddingBottom--normal u-marginBottom--normal">Replicated Entitlements</h3>
-                {{ with .Site.GetPage "section" "docs" "entitlements" }}
+                {{ with .Site.GetPage "/docs/entitlements" }}
                     {{ range .Pages }}
                         <p class="u-paddingTop--small u-fontSize--normal u-lineHeight--normal">
                             <a href="{{ .Permalink }}" class="{{ if and (eq .Title $currentPage.Title) (eq .CurrentSection $currentSection) }} u-color--curiousBlueDark u-fontWeight--bold {{ else }} u-color--curiousBlue {{ end }}">


### PR DESCRIPTION
Hugo v0.47 changes GetPage to take just a single parameter, which was causing numerous render errors.  Looks like there are still various calls to GetPage with multiple params, but these are the minimal fixes to get "hugo serve" to actually serve.