### PR TITLE
take a pass at swarm docs

### DIFF
--- a/content/docs/kubernetes/getting-started/create-licenses.md
+++ b/content/docs/kubernetes/getting-started/create-licenses.md
@@ -15,6 +15,8 @@ Each customer you deploy to via Replicated will need a separate license file for
 
 If you are looking to create or manage custom license fields you can do so in the License Fields section of the [vendor portal](https://vendor.replicated.com/) or via the [Vendor License API](/api/vendor-api). License values are used by Replicated to enable/disable various functionality, many of the values are also available in the on-prem instance via the [license integration API](https://replicated.readme.io/docs/license-api).
 
+![](/images/post-screens/create-customer.png)
+
 {{< linked_headline "Name (Required)" >}}
 
 The name of the customer to whom this license is assigned.

--- a/content/docs/kubernetes/getting-started/development-environment.md
+++ b/content/docs/kubernetes/getting-started/development-environment.md
@@ -58,7 +58,7 @@ During Studio installation on your local development machine, a new directory na
 From there you can use your favorite editor locally (like Atom, Visual Studio Code, Vim, or Emacs) and saved changes will trigger new updates available to your development server.
 
 **_Note: In the directory `~/replicated/releases/` you can view a copy of each release Replicated Studio has created along the way._**
-If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` save a new version of `current.yaml`.
+If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` and save a new version of `current.yaml`.
 
 ### Applying updates to the dev server
 

--- a/content/docs/kubernetes/getting-started/docker-registries.md
+++ b/content/docs/kubernetes/getting-started/docker-registries.md
@@ -13,7 +13,7 @@ When building your application, you have the option to use the Replicated privat
 
 {{< linked_headline "Replicated Registry" >}}
 
-Every application created in Replicated has a completely isolated, private Docker registry available. You can push images to your private registry by finding the endpoint at (https://vendor.replicated.com/#/images) and using the Docker CLI to tag and push images. When using the Kubernetes Scheduler, Replicated will be able to automatically use the customer license file to authenticate and pull any images from the Replicated Registry.
+Every application created in Replicated has a private, [completely isolated](/docs/registry/security) private Docker registry available. You can push images to your private registry by finding the endpoint at (https://vendor.replicated.com/#/images) and using the Docker CLI to tag and push images. When using the Kubernetes Scheduler, Replicated will be able to automatically use the customer license file to authenticate and pull any images from the Replicated Registry.
 
 {{< linked_headline "Tagging Images" >}}
 

--- a/content/docs/kubernetes/getting-started/manage-releases.md
+++ b/content/docs/kubernetes/getting-started/manage-releases.md
@@ -18,7 +18,7 @@ Once a release is ready to be installed, the release can be promoted to one or m
 
 {{< linked_headline "Manage Release Channels" >}}
 
-By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you'll see these default release channels created. You can delete, edit or create new channels at any time. The channels we create by default are commonly used:
+By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you'll see these default release channels created. You can delete, edit or create new channels at any time. The channels Replicated creates by default are commonly used for:
 
 ### Unstable
 The Unstable channel is designed for you to constantly push releases to, much in the same way that you continuously deploy new versions to your cloud product. This is the channel that your development environment should have a license assigned to. This channel is designed to be internal and for testing, not for your customers to be licensed against.

--- a/content/docs/native/getting-started/create-licenses.md
+++ b/content/docs/native/getting-started/create-licenses.md
@@ -13,6 +13,8 @@ Each customer you deploy to via Replicated will need a separate license file for
 
 If you are looking to create or manage custom license fields you can do so in the License Fields section of the [vendor portal](https://vendor.replicated.com/) or via the [Vendor License API](/api/vendor-api). License values are used by Replicated to enable/disable various functionality, many of the values are also available in the on-prem instance via the [license integration API](https://replicated.readme.io/docs/license-api).
 
+![](/images/post-screens/create-customer.png)
+
 {{< linked_headline "Name (Required)" >}}
 
 The name of the customer to whom this license is assigned.

--- a/content/docs/native/getting-started/developer-environment.md
+++ b/content/docs/native/getting-started/developer-environment.md
@@ -53,7 +53,7 @@ During Studio installation on your local development machine, a new directory na
 From there you can use your favorite editor locally (like Atom, Visual Studio Code, Vim, or Emacs) and saved changes will trigger new updates available to your development server.
 
 **_Note: In the directory `~/replicated/releases/` you can view a copy of each release Replicated Studio has created along the way._**
-If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` save a new version of `current.yaml`.
+If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` and save a new version of `current.yaml`.
 
 ### Applying updates to the dev server
 

--- a/content/docs/native/getting-started/docker-registries.md
+++ b/content/docs/native/getting-started/docker-registries.md
@@ -13,7 +13,7 @@ When building your application, you have the option to use the Replicated privat
 
 {{< linked_headline "Replicated Registry" >}}
 
-Every application created in Replicated has a completely isolated, private Docker registry available. You can push images to your private registry by finding the endpoint at (https://vendor.replicated.com/#/images) and using the Docker CLI to tag and push images. The Replicated Native Scheduler has built in support for the private registry, and will automatically authenticate with read-only access from a customer license file.
+Every application created in Replicated has a private, [completely isolated](/docs/registry/security) Docker registry available. You can push images to your private registry by finding the endpoint at (https://vendor.replicated.com/#/images) and using the Docker CLI to tag and push images. The Replicated Native Scheduler has built in support for the private registry, and will automatically authenticate with read-only access from a customer license file.
 
 {{< linked_headline "Tagging Images" >}}
 

--- a/content/docs/native/getting-started/manage-releases.md
+++ b/content/docs/native/getting-started/manage-releases.md
@@ -19,7 +19,7 @@ Once a release is ready to be installed, the release can be promoted to one or m
 
 {{< linked_headline "Manage Release Channels" >}}
 
-By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you'll see these default release channels created. You can delete, edit or create new channels at any time. The channels we create by default are commonly used:
+By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you'll see these default release channels created. You can delete, edit or create new channels at any time. The channels Replicated creates by default are commonly used for:
 
 ### Unstable
 The Unstable channel is designed for you to constantly push releases to, much in the same way that you continuously deploy new versions to your cloud product. This is the channel that your development environment should have a license assigned to. This channel is designed to be internal and for testing, not for your customers to be licensed against.

--- a/content/docs/swarm/getting-started/create-licenses.md
+++ b/content/docs/swarm/getting-started/create-licenses.md
@@ -13,6 +13,8 @@ Each customer you deploy to via Replicated will need a separate license file for
 
 If you are looking to create or manage custom license fields you can do so in the License Fields section of the [vendor portal](https://vendor.replicated.com/) or via the [Vendor License API](/api/vendor-api). License values are used by Replicated to enable/disable various functionality, many of the values are also available in the on-prem instance via the [license integration API](https://replicated.readme.io/docs/license-api).
 
+![](/images/post-screens/create-customer.png)
+
 {{< linked_headline "Name (Required)" >}}
 
 The name of the customer to whom this license is assigned.

--- a/content/docs/swarm/getting-started/development-environment.md
+++ b/content/docs/swarm/getting-started/development-environment.md
@@ -52,7 +52,7 @@ During Studio installation on your local development machine, a new directory na
 From there you can use your favorite editor locally (like Atom, Visual Studio Code, Vim, or Emacs) and saved changes will trigger new updates available to your development server.
 
 **_Note: In the directory `~/replicated/releases/` you can view a copy of each release Replicated Studio has created along the way._**
-If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` save a new version of `current.yaml`.
+If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` and save a new version of `current.yaml`.
 
 ### Applying updates to the dev server
 

--- a/content/docs/swarm/getting-started/docker-registries.md
+++ b/content/docs/swarm/getting-started/docker-registries.md
@@ -14,7 +14,7 @@ When building your application, you have the option to use the Replicated privat
 
 {{< linked_headline "Replicated Registry" >}}
 
-Every application created in Replicated has a completely isolated, private Docker registry available. You can push images to your private registry by finding the endpoint at (https://vendor.replicated.com/#/images) and using the Docker CLI to tag and push images. When using the Swarm Scheduler, Replicated will be able to automatically use the customer license file to authenticate and pull any images from the Replicated Registry.
+Every application created in Replicated has a private, [completely isolated](/docs/registry/security) Docker registry available. You can push images to your private registry by finding the endpoint at (https://vendor.replicated.com/#/images) and using the Docker CLI to tag and push images. When using the Swarm Scheduler, Replicated will be able to automatically use the customer license file to authenticate and pull any images from the Replicated Registry.
 
 {{< linked_headline "Tagging Images" >}}
 
@@ -62,9 +62,15 @@ When using Docker Swarm, Replicated supports pulling public, unauthenticated ima
 
 Additionally, Replicated supports private images hosted in other registries including Docker Hub, Quay.io and more. Currently, Replicated does not support private images in Amazon Elastic Container Registry because of the short-lived auth scheme in use.
 
-To use private images from an external registry, you need to add the registry via the Vendor website. The guide for [integrating a third party registry](/docs/kb/developer-resources/third-party-registries) explains this in further detail.
+To use private images from an external registry, you need to add the registry via the Vendor website. The guide for [integrating a third party registry](/docs/kb/developer-resources/third-party-registries) explains this in further detail. You'll also need to [declare](#declaring-images) any external registry images in an `images` section in your Replicated YAML.
 
-All images included in your Swarm application must be specified in the `images` section of your YAML in order to be included in the airgap bundle your customer will download and install.
+
+
+{{< linked_headline "Declaring Images" >}}
+
+To include images in your application, you'll need to add them to your YAML as follows.
+
+All public and private images included in your Swarm application must be specified in this `images` section of your YAML in order to be included in the airgap bundle your customer will download and install.
 
 ```yaml
 images:

--- a/content/docs/swarm/getting-started/manage-releases.md
+++ b/content/docs/swarm/getting-started/manage-releases.md
@@ -11,7 +11,7 @@ gradient: "swarm"
 
 {{< linked_headline "Create Releases" >}}
 
-The [Replicated vendor portal](https://vendor.replicated.com) provides you with a location to create and release versions of your application to various release channels. The vendor portal hosts a built-in YAML editor and linter to help you write and validate YAML for the Replicated Native Scheduler.
+The [Replicated vendor portal](https://vendor.replicated.com) provides you with a location to create and release versions of your application to various release channels. The vendor portal hosts a built-in YAML editor and linter to help you write and validate YAML for the Replicated Swarm Scheduler.
 
 {{< linked_headline "Promoting Releases" >}}
 
@@ -19,7 +19,7 @@ Once a release is ready to be installed, the release can be promoted to one or m
 
 {{< linked_headline "Manage Release Channels" >}}
 
-By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you'll see these default release channels created. You can delete, edit or create new channels at any time. The channels we create by default are commonly used:
+By default, there are 3 release channels: Stable, Beta and Unstable. When you first log in to Replicated and select the Channels tab, you'll see these default release channels created. You can delete, edit or create new channels at any time. The channels Replicated creates by default are commonly used for:
 
 ### Unstable
 The Unstable channel is designed for you to constantly push releases to, much in the same way that you continuously deploy new versions to your cloud product. This is the channel that your development environment should have a license assigned to. This channel is designed to be internal and for testing, not for your customers to be licensed against.

--- a/content/guides/iterate-with-replicated-studio/iterate.md
+++ b/content/guides/iterate-with-replicated-studio/iterate.md
@@ -18,7 +18,7 @@ During Studio installation on your local development machine, a new directory na
 From there you can use your favorite editor locally (like Atom, Visual Studio Code, Vim, or Emacs) and saved changes will trigger new updates available to your development server.
 
 **_Note: In the directory `~/replicated/releases/` you can view a copy of each release Replicated Studio has created along the way._**
-If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` save a new version of `current.yaml`.
+If you supply an invalid yaml file that isn't recognized as a valid update in the on-prem UI, you can simply delete the invalid release iteration from the local directory `~/replicated/releases` and save a new version of `current.yaml`.
 
 ### Applying updates to the dev server
 


### PR DESCRIPTION
For swarm:

- Put `images` section under a `Declaring Images` header, trying to make
  it more clear that these need to be included for TPR even in online
  installs
- Change a few (maybe just 1) `Replicated Native` -> `Replicated Swarm`

For all three schedulers:

- Add screenshots of Create Customer form to  "create-licenses" page
- tweak some wording on studio setup guide
- link to registry security doc from registry intro
- reword default channels descriptions