### PR TITLE
add link checker to prod, fix broken links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
 version: 2
+experimental:
+  notify:
+    branches:
+      only:
+      - master
 
 environment: &environment
   environment:
@@ -33,6 +38,14 @@ hugo_setup_steps: &hugo_setup_steps
     sudo mv hugo /usr/bin/hugo
 
 jobs:
+  linkcheck_prod:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Link Check Production
+          command: |
+                  make linkcheck
   build_staging:
     <<: *defaults_py
     steps:
@@ -210,6 +223,12 @@ workflows:
             branches:
               only: master
       - build_prod_index:
+          requires:
+            - deploy_production
+          filters:
+            branches:
+              only: master
+      - linkcheck_prod:
           requires:
             - deploy_production
           filters:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VENDOR_SWAGGER_SOURCE ?= "https://api.replicated.com/vendor"
-
+ 
+SHELL := /bin/bash -o pipefail
 install:
 	yarn
 
@@ -38,3 +39,34 @@ setup:
 	mkdir -p java
 	curl -o java/swagger2markup-cli-1.3.1.jar http://central.maven.org/maven2/io/github/swagger2markup/swagger2markup-cli/1.3.1/swagger2markup-cli-1.3.1.jar
 	curl -o java/swagger2markup-1.3.1.jar http://central.maven.org/maven2/io/github/swagger2markup/swagger2markup/1.3.1/swagger2markup-1.3.1.jar
+
+
+# this skips *all* of community, but its a start
+# it only really works against prod right now, but with some more exclusions 
+# it could probably work for staging as well. Notably, we have no community
+# in staging. For now just want to run this in prod and see how it feels,
+# not blocking any builds yet.
+linkcheck:
+	npm install broken-link-checker@0.7.8
+	`npm bin`/blc https://help.replicated.com -r \
+		--host-requests 20 \
+		--requests 20 \
+		\
+		--exclude 'server:8800' \
+		--exclude '10.128.0.4' \
+		--exclude 'get.company.com/docker' \
+		\
+		--exclude 'golang.org' \
+		--exclude 'circleci.com' \
+		--exclude 'registry.replicated.com' \
+		--exclude 'registry-data.replicated.com' \
+		--exclude 'api.replicated.com' \
+		--exclude 'get.replicated.com' \
+		\
+		--exclude 'help.replicated.com/community' \
+		--exclude 'help.replicated.com/tos'  \
+		--exlcude 'help.replicated.com/faq' \
+		--exclude 'help.replicated.com/privacy' \
+		--exclude 'help.replicated.com/guidelines' \
+		\
+		--color=always  | grep -E 'Getting|Finished|BROKEN|^$$'

--- a/content/docs/ship/playbooks/registry-kubernetes.md
+++ b/content/docs/ship/playbooks/registry-kubernetes.md
@@ -47,7 +47,7 @@ assets:
 
 {{< linked_headline "Shipping a Docker Registry for airgap installations" >}}
 
-When distributing a Kubernetes (or Helm) application, most customers will be able to provide a Docker registry that required application images can be pushed to. Replicated Ship can [retag and rewrite the Kubernetes YAML](/docs/ship/recipes/airgap-kubernetes/) to work in this scenario.
+When distributing a Kubernetes (or Helm) application, most customers will be able to provide a Docker registry that required application images can be pushed to. Replicated Ship can [retag and rewrite the Kubernetes YAML](/docs/ship/playbooks/airgap-kubernetes/) to work in this scenario.
 
 If the Kubernetes cluster ] was set up using the [Replicated Kubernetes installer](/docs/kubernetes/customer-installations/installing-k8s-only/), a Docker registry might not be available. The Replicated Kubernetes installer will pre-pull the `registry:2` image on all nodes in the cluster.
 

--- a/content/guides/helm-application/introduction.md
+++ b/content/guides/helm-application/introduction.md
@@ -31,7 +31,7 @@ The most common use of Replicated Ship is to distribute a Kubernetes (or Helm) a
 
 ### Customizable Installation/Update Process
 
-When the end customer installs a Ship application, Ship will launch a branded and customizable web-based setup console. It's here that customized [commands](/docs/ship/commands) can generate data such as keys, certs, random strings, etc. The console also shows an interactive form for the operator to input data that's required to start the application.
+When the end customer installs a Ship application, Ship will launch a branded and customizable web-based setup console. It's here that customized [config options](/docs/ship/config/overview) can generate data such as keys, certs, random strings, etc. The console also shows an interactive form for the operator to input data that's required to start the application.
 
 The web-based console is a nice, user friendly way to set up the application, but automation is a big part of Ship. When an application is distributed on Ship, it's easy for the operator to automate the configuration and update process so any updates can be applied to a change management process and then staged for deployment. This can even be used to create a continuous delivery process for your on-prem software.
 

--- a/content/guides/troubleshoot/github.md
+++ b/content/guides/troubleshoot/github.md
@@ -11,7 +11,7 @@ icon: "troubleshoot"
 nextPage: "/api/support-bundle-yaml.md"
 ---
 
-Once you've [created a support bundle spec](/guides/troubleshoot/spec) and have [collected a few bundles from your customers](/guides/support-bundle/generate), it's a good idea to check your spec into source control and treat it the same way you'd treat other code. Having a process around code reviews and being able to accept pull requests to update the spec is useful and supported by Replicated.
+Once you've [created a support bundle spec](/guides/troubleshoot/spec) and have [collected a few bundles from your customers](/guides/troubleshoot/generate), it's a good idea to check your spec into source control and treat it the same way you'd treat other code. Having a process around code reviews and being able to accept pull requests to update the spec is useful and supported by Replicated.
 
 On the Create a new Support Bundle Spec page, enable the "Link to spec in GitHub" option. If you haven't yet linked your GitHub account to your Replicated account, you'll be prompted to log in to GitHub.
 

--- a/content/guides/troubleshoot/iterating.md
+++ b/content/guides/troubleshoot/iterating.md
@@ -45,7 +45,7 @@ specs:
     output_dir: "/dns/resolv"
 ```
 
-That's it! Now we can save this spec, and collect another support bundle using the same command we ran in [Generate a Support Bundle](/guides/support-bundle/generate). Our new bundle should now contain the additional files we requested:
+That's it! Now we can save this spec, and collect another support bundle using the same command we ran in [Generate a Support Bundle](/guides/troubleshoot/generate). Our new bundle should now contain the additional files we requested:
 
 ```shell
 $ docker run ... # etc


### PR DESCRIPTION
This doesn't block anything in CI yet, it just runs
after production is deployed. It also completely ignores anything
on community, although that's something to tackle as well at some point.

Here's an example of a build failing due to a few broken links in prod
(which are also incidentally fixed in this PR)

https://circleci.com/gh/dexhorthy/help-center/7