### PR TITLE
Update troubleshoot docs, remove v1.0 example from swarm.

### DIFF
--- a/content/docs/kubernetes/packaging-an-application/support-bundle-v1.md
+++ b/content/docs/kubernetes/packaging-an-application/support-bundle-v1.md
@@ -1,0 +1,38 @@
+---
+date: "2017-11-17T00:00:00Z"
+title: "Support Bundle (Older Instances)"
+description: "Installed instances can generate a support bundle with relevant logs and instance information."
+categories: [ "Packaging a Kubernetes Application" ]
+index: ["docs/kubernetes", "docs"]
+hideFromList: true
+icon: "replicatedKubernetes"
+gradient: "kubernetes"
+---
+
+{{< note title="Support Bundle v1" >}}
+This is the documentation for the pre-2.0 version of the Support Bundle. If you signed up for Replicated during or after February 2018, you will have the 2.0 version by default. If you signed up before that date, you'll have the option to opt-in to the 2.0 support bundle on a per-customer basis. If you'd like to move all your customers to [version 2](../support-bundle), please contact support@replicated.com.
+{{< /note >}}
+
+{{< linked_headline "Custom Files and Commands" >}}
+
+In addition to the [default support files](/docs/kubernetes/packaging-an-application/support-bundle/#default-support-files) included in the support bundle, addtional files can be added via the `support` section of your yaml. Files from within the application’s containers can be included, as well as output of commands executed in the container. For more complex support commands it is possible to create a [config file](/docs/kubernetes/packaging-an-application/config-files/) and execute that file from a support command. 
+
+```yaml
+support:
+  files:
+    - filename: /var/log/nginx/access.log
+      kubernetes:
+        selector: # pod label selector
+          app: my-app
+  commands:
+    - filename: access_last_1000.log
+      command: [tail, -n1000, /var/log/nginx/access.log]
+      kubernetes:
+        selector: # pod label selector
+          app: my-app
+```
+
+{{< linked_headline "Excluding Logs From Support Bundles" >}}
+
+If a pod's logs may contain sensitive information or are simply large and not useful for your debugging processes, you can exclude that pod's logs from support bundles. To do this, add the label `com.replicated.excludelogs=true` to the pod in question.
+

--- a/content/docs/kubernetes/packaging-an-application/support-bundle.md
+++ b/content/docs/kubernetes/packaging-an-application/support-bundle.md
@@ -9,7 +9,7 @@ gradient: "kubernetes"
 icon: "replicatedKubernetes"
 ---
 
-A support bundle is an archive that is available for the customer to download via the Support tab of the On-Prem Console or the [Replicated CLI](/api/replicatedctl/replicatedctl_support-bundle/).
+A support bundle is an archive that is available for the customer to download via the Support tab of the Admin Console or the [Replicated CLI](/api/replicatedctl/replicatedctl_support-bundle/).
 
 Contents of the support page can be customized by including markdown in the top-level of the YAML.
 
@@ -31,8 +31,11 @@ support:
 
 {{< linked_headline "Custom Files and Commands" >}}
 
-Custom support bundle files and commands can be included by setting a default troubleshoot spec in [Replicated Console](https://console.replicated.com/troubleshoot/specs). The support bundle task definitions can be found [here](/api/support-bundle-yaml-specs/shared).
+{{< note title="Support Bundle 2.0" >}}
+The remainder of this document is specific to the current default Support Bundle in Replicated. If you are looking for the v1 version of this document, it is available at <a href="/docs/kubernetes/packaging-an-application/support-bundle-v1/">Support Bundle (Older Instances)</a>
+{{< /note >}}
 
+In addition to the [default support files](/docs/kubernetes/packaging-an-application/support-bundle/#default-support-files) included in the support bundle, addtional files can be added via A [custom troubleshoot spec](/docs/troubleshoot/collectors/overview). Files from within the application’s containers can be included, as well as output of commands executed in any of your app's containers.
 
 {{< linked_headline "Excluding Logs From Support Bundles" >}}
 

--- a/content/docs/swarm/packaging-an-application/support-bundle-v1.md
+++ b/content/docs/swarm/packaging-an-application/support-bundle-v1.md
@@ -9,6 +9,32 @@ icon: "replicatedDockerSwarm"
 gradient: "swarm"
 ---
 
+{{< note title="Support Bundle v1" >}}
+This is the documentation for the pre-2.0 version of the Support Bundle. If you signed up for Replicated during or after February 2018, you will have the 2.0 version by default. If you signed up before that date, you'll have the option to opt-in to the 2.0 support bundle on a per-customer basis. If you'd like to move all your customers to [version 2](../support-bundle), please contact support@replicated.com.
+{{< /note >}}
+
+{{< linked_headline "Custom Files and Commands" >}}
+
+In addition to the [default support files](/docs/swarm/packaging-an-application/support-bundle/#default-support-files) included in the support bundle, addtional files can be added via the `support` section of your yaml. Files from within the application’s containers can be included, as well as output of commands executed in the container. For more complex support commands it is possible to create a [config file](/docs/swarm/packaging-an-application/config-files/) and execute that file from a support command. 
+
+```yaml
+support:
+  files:
+    - filename: /var/log/nginx/access.log
+      swarm:
+        service: my-nginx-service
+  commands:
+    - filename: access_last_1000.log
+      command: [tail, -n1000, /var/log/nginx/access.log]
+      swarm:
+        service: my-nginx-service
+
+```
+
+{{< linked_headline "Excluding Logs From Support Bundles" >}}
+
+If a pod's logs may contain sensitive information or are simply large and not useful for your debugging processes, you can exclude that pod's logs from support bundles. To do this, add the label `com.replicated.excludelogs=true` to the pod in question.
+
 {{< linked_headline "Default Support Files" >}}
 
 By default the Support Bundle V1 will include the following files:

--- a/content/docs/swarm/packaging-an-application/support-bundle.md
+++ b/content/docs/swarm/packaging-an-application/support-bundle.md
@@ -31,23 +31,14 @@ support:
 
 {{< linked_headline "Custom Files and Commands" >}}
 
-<!-- TODO this next paragraph assumes/implies v1, and we ought to figure out the best way to convey v1/v2 differences -->
+{{< note title="Support Bundle 2.0" >}}
+The remainder of this document is specific to the current default Support Bundle in Replicated. If you are looking for the v1 version of this document, it is available at <a href="/docs/swarm/packaging-an-application/support-bundle-v1/">{{< baseurl >}}/docs/swarm/packaging-an-application/support-bundle-v1/</a>
+{{< /note >}}
 
-In addition to the [default support files](/docs/swarm/packaging-an-application/support-bundle/#default-support-files) included in the support bundle, addtional files can be added via the `support` section of your yaml. Files from within the application’s containers can be included, as well as output of commands executed in the container. Support files and commands are supported by both the native and kubernetes schedulers. For more complex support commands it is possible to create a [config file](/docs/packaging-an-application/components-and-containers/#config-files) and execute that file from a support command. These files will be available withing the */scheduler* directory of the support bundle.
+{{< linked_headline "Custom Files and Commands" >}}
 
-```yaml
-support:
-  files:
-    - filename: /var/log/nginx/access.log
-      swarm:
-        service: my-nginx-service
-  commands:
-    - filename: access_last_1000.log
-      command: [tail, -n1000, /var/log/nginx/access.log]
-      swarm:
-        service: my-nginx-service
+In addition to the [default support files](/docs/swarm/packaging-an-application/support-bundle/#default-support-files) included in the support bundle, addtional files can be added via A [custom troubleshoot spec](/docs/troubleshoot/collectors/overview). Files from within the application’s containers can be included, as well as output of commands executed in any of your app's containers.
 
-```
 
 {{< linked_headline "Excluding Logs From Support Bundles" >}}
 
@@ -62,10 +53,6 @@ services:
 ```
 
 {{< linked_headline "Default Support Files" >}}
-
-{{< note title="Legacy Support Bundle" >}}
-The content in this document is specific to the current default Support Bundle in Replicated. If you are looking for the legacy Support Bundle version of this document, it is available at <a href="/docs/swarm/packaging-an-application/support-bundle-v1/">{{< baseurl >}}/docs/swarm/packaging-an-application/support-bundle-v1/</a>
-{{< /note >}}
 
 By default the Support Bundle will include the following files in the master folder:
 
@@ -87,7 +74,7 @@ By default the Support Bundle will include the following files in the master fol
 | /default/commands/ps/stdout | Report a snapshot of the current processes. Result of the command `ps fauxwww` |
 | /default/commands/uptime/uptime | Tell how long the system has been running. Result of the command `uptime` |
 | /default/docker/container_ls.json | List all containers. Result of the command `docker ps -a` |
-| /default/docker/docker_info.json | Display system-wide information | 
+| /default/docker/docker_info.json | Display system-wide information |
 | /default/docker/docker_version.json | Docker version output |
 | /default/docker/image_ls.json | List all images. Result of the command `docker images`|
 | /default/etc/centos-release | Operating system identification data for centos distributions. A copy of the `/etc/centos-release` file. |
@@ -171,7 +158,7 @@ the private IP of the instance. It will contain the following files:
 | /default/commands/ip_route_show/stdout | Show routing table entries. Result of the command `ip -o route show` |
 | /default/commands/ps/stdout | Report a snapshot of the current processes. Result of the command `ps fauxwww` |
 | /default/commands/uptime/uptime | Tell how long the system has been running. Result of the command `uptime` |
-| /default/docker/docker_info.json | Display system-wide information | 
+| /default/docker/docker_info.json | Display system-wide information |
 | /default/docker/docker_version.json | Docker version output |
 | /default/docker/container_ls.json | List all containers. Result of the command `docker ps -a` |
 | /default/etc/centos-release | Operating system identification data for centos distributions. A copy of the `/etc/centos-release` file. |


### PR DESCRIPTION
This is analogous to the native-specific stuff happening in https://github.com/replicatedhq/help-center/pull/524/files