### PR TITLE
test proc success results not formattable

### DIFF
--- a/content/docs/kubernetes/packaging-an-application/programmable-test-procs.md
+++ b/content/docs/kubernetes/packaging-an-application/programmable-test-procs.md
@@ -15,6 +15,7 @@ Programmable Test Procedures enable you to run an arbitrary Pods to validate the
 
 The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-kubernetes`. The `test_proc.results` property can be utilized to interpret output from the Pod and format it for display to the end-user.
 The `test_proc.results` property can be used to interpret output from the container and format any errors for display to the end-user.
+Note the reference to the Service spec that has been added to the release yaml with kind `test-proc-kubernetes`.
 
 ```yaml
 ---

--- a/content/docs/kubernetes/packaging-an-application/programmable-test-procs.md
+++ b/content/docs/kubernetes/packaging-an-application/programmable-test-procs.md
@@ -13,7 +13,8 @@ Programmable Test Procedures enable you to run an arbitrary Pods to validate the
 
 {{< linked_headline "Example" >}}
 
-The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-kubernetes`. The `test_proc.results` property can be utilized to interpret output from the Pod and format it for display to the end-user. Note the reference to the Service spec that has been added to the release yaml with kind `test-proc-kubernetes`.
+The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-kubernetes`. The `test_proc.results` property can be utilized to interpret output from the Pod and format it for display to the end-user.
+The `test_proc.results` property can be used to interpret output from the container and format any errors for display to the end-user.
 
 ```yaml
 ---

--- a/content/docs/kubernetes/packaging-an-application/programmable-test-procs.md
+++ b/content/docs/kubernetes/packaging-an-application/programmable-test-procs.md
@@ -13,7 +13,7 @@ Programmable Test Procedures enable you to run an arbitrary Pods to validate the
 
 {{< linked_headline "Example" >}}
 
-The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-kubernetes`. The `test_proc.results` property can be utilized to interpret output from the Pod and format it for display to the end-user.
+The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-kubernetes`.
 The `test_proc.results` property can be used to interpret output from the container and format any errors for display to the end-user.
 Note the reference to the Service spec that has been added to the release yaml with kind `test-proc-kubernetes`.
 

--- a/content/docs/native/packaging-an-application/programmable-test-procs.md
+++ b/content/docs/native/packaging-an-application/programmable-test-procs.md
@@ -12,7 +12,8 @@ Programmable Test Procedures enable you to run an arbitrary containers to valida
 
 {{< linked_headline "Example" >}}
 
-The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a container defined in the components section of the YAML. The `test_proc.results` property can be utilized to interpret output from the container and format it for display to the end-user.
+The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a container defined in the components section of the YAML.
+The `test_proc.results` property can be used to interpret output from the container and format any errors for display to the end-user.
 
 ```yaml
 config:

--- a/content/docs/swarm/packaging-an-application/programmable-test-procs.md
+++ b/content/docs/swarm/packaging-an-application/programmable-test-procs.md
@@ -13,7 +13,8 @@ Programmable Test Procedures enable you to run an arbitrary Services to validate
 
 {{< linked_headline "Example" >}}
 
-The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-swarm`. The `test_proc.results` property can be utilized to interpret output from the Service and format it for display to the end-user. Note the reference to the Service spec that has been added to the release yaml with kind `test-proc-swarm`.
+The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-swarm`. The `test_proc.results` property can be utilized to interpret output from the Service and format it for display to the end-user.
+The `test_proc.results` property can be used to interpret output from the container and format any errors for display to the end-user.
 
 ```yaml
 ---

--- a/content/docs/swarm/packaging-an-application/programmable-test-procs.md
+++ b/content/docs/swarm/packaging-an-application/programmable-test-procs.md
@@ -13,8 +13,9 @@ Programmable Test Procedures enable you to run an arbitrary Services to validate
 
 {{< linked_headline "Example" >}}
 
-The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-swarm`. The `test_proc.results` property can be utilized to interpret output from the Service and format it for display to the end-user.
+The following example will check the validity of the password entered by the end-user. The `test_proc.custom_command` property of the YAML will instruct Replicated to run a service defined in a special YAML file defined with kind `test-proc-swarm`.
 The `test_proc.results` property can be used to interpret output from the container and format any errors for display to the end-user.
+Note the reference to the Service spec that has been added to the release yaml with kind `test-proc-swarm`.
 
 ```yaml
 ---


### PR DESCRIPTION
Replicated UI ignores any custom test proc result when the status is success.