### PR TITLE
Do not use `path` until Rook/Ceph bug is fixed

### DIFF
--- a/content/docs/kubernetes/packaging-an-application/template-functions.md
+++ b/content/docs/kubernetes/packaging-an-application/template-functions.md
@@ -489,29 +489,6 @@ func Namespace() string
 
 Namespace returns the value of the namespace the vendor application is installed in.
 
-{{< template_function name="ServiceAddress" replicated="false" kubernetes="true" swarm="false" >}}
-```go
-ServiceAddress(name string, port int32) string
-```
-
-ServiceAddress returns the address of the ingress.
-
-```yaml
-properties:
-  app_url: '{{repl ServiceAddress "frontend" 80 }}'
-```
-
-{{< template_function name="IngressAddress" replicated="false" kubernetes="true" swarm="false" >}}
-```go
-IngressAddress(name string, port int32) string
-```
-
-IngressAddress returns the address of the ingress.
-
-```yaml
-properties:
-  app_url: '{{repl IngressAddress "frontend" 80 }}'
-```
 
 {{< template_function name="PremkitAPIAddress" replicated="false" kubernetes="true" swarm="true" >}}
 ```go

--- a/content/docs/kubernetes/packaging-an-application/volumes.md
+++ b/content/docs/kubernetes/packaging-an-application/volumes.md
@@ -76,10 +76,12 @@ spec:
           options:
             fsName: rook-shared-fs
             clusterNamespace: rook-ceph
-            path: /subdir1 #optional
 ```
 
-Paths within the shared filesystem can be included in snapshots by adding them to the [backup](/docs/snapshots/kubernetes/) section of your yaml.
+{{< warning title="Using the path option" >}}
+Due to an open bug in Rook/Ceph, custom `path` for `flexVolume` should be avoided, if its ommitted the `path` defaults to `/`. For snapshots the `path` (in this case `/`) also needs to be included in the [backup](/docs/snapshots/kubernetes/) section of your yaml.
+{{</warning>}}
+
 
 {{< linked_headline "Resources" >}}
 

--- a/content/docs/kubernetes/packaging-an-application/yaml-format.md
+++ b/content/docs/kubernetes/packaging-an-application/yaml-format.md
@@ -34,7 +34,7 @@ The properties section includes definitions of some optional (but recommended) a
 
 ```yaml
 properties:
-  app_url: http://{{repl ServiceAddress nginx }}
+  app_url: http://{{repl ConsoleSetting "tls.hostname" }}
   console_title: My Enterprise Application
 ```
 


### PR DESCRIPTION
- Do not use `path` until Rook/Ceph bug is fixed.
- Remove ServiceAddress and IngressAddress from K8s docs because they've been deprecated.