### PR TITLE
update data transmission policy to match community page language

### DIFF
--- a/content/data-transmission-policy/_index.md
+++ b/content/data-transmission-policy/_index.md
@@ -9,7 +9,6 @@ A Replicated installation connects to a Replicated-hosted endpoint periodically 
 - The IP address of the primary Replicated instance.</li>
 - The ID of the installation.</li>
 - The state of the installation (running, stopped, etc).</li>
-- The current version of the installation.</li>
-- The current version of the Replicated components.</li>
+- Information about the installation (version of the app, version of Replicated components, version of Kubernetes, version of Kubernetes addons, etc.).</li>
 
 This data is required to provide the expected update and license services. No additional data is collected and transmitted by default from the instance to external servers.

--- a/content/data-transmission-policy/_index.md
+++ b/content/data-transmission-policy/_index.md
@@ -12,3 +12,5 @@ A Replicated installation connects to a Replicated-hosted endpoint periodically 
 - Information about the installation (version of the app, version of Replicated components, version of Kubernetes, version of Kubernetes addons, etc.).</li>
 
 This data is required to provide the expected update and license services. No additional data is collected and transmitted by default from the instance to external servers.
+
+<i>Last modified October 16, 2020</i>


### PR DESCRIPTION
Per 2-12-21 product conversation, we wanted to update this site to match the language currently on the community page here: https://help.replicated.com/community/t/replicated-data-transmission-policy/53